### PR TITLE
Add Red Hat Molecule scenario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 ansible.cfg
 inventory
 config.yml
+
+# Local VM target values for Molecule VM-over-SSH scenarios
+.molecule-vm.env
+.molecule-vm-logs/

--- a/.molecule-vm.env.example
+++ b/.molecule-vm.env.example
@@ -1,0 +1,27 @@
+# BrightOS Molecule VM targets (copy to .molecule-vm.env and edit)
+#
+# This file is sourced by scripts/molecule-vm-env.sh.
+# Keep it local/private if hostnames or usernames are sensitive.
+
+# Shared defaults (optional)
+MOLECULE_VM_USER=brightos
+MOLECULE_VM_PORT=22
+MOLECULE_VM_KEY=~/.ssh/id_ed25519
+MOLECULE_VM_SSH_COMMON_ARGS='-o StrictHostKeyChecking=accept-new'
+
+# Ubuntu VM target
+MOLECULE_VM_UBUNTU_HOST=192.0.2.10
+# Optional per-target overrides:
+# MOLECULE_VM_UBUNTU_USER=brightos
+# MOLECULE_VM_UBUNTU_PORT=22
+# MOLECULE_VM_UBUNTU_KEY=~/.ssh/id_ed25519
+# MOLECULE_VM_UBUNTU_SSH_COMMON_ARGS='-o StrictHostKeyChecking=accept-new'
+
+# AlmaLinux VM target
+MOLECULE_VM_ALMALINUX_HOST=192.0.2.20
+# Optional per-target overrides:
+# MOLECULE_VM_ALMALINUX_USER=brightos
+# MOLECULE_VM_ALMALINUX_PORT=22
+# MOLECULE_VM_ALMALINUX_KEY=~/.ssh/id_ed25519
+# MOLECULE_VM_ALMALINUX_SSH_COMMON_ARGS='-o StrictHostKeyChecking=accept-new'
+

--- a/config.yml.example
+++ b/config.yml.example
@@ -1,7 +1,7 @@
 ---
 # Copy this file to config.yml and edit to suit you.
 server_timezone: Europe/London # For acceptable entries here, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-snl_user: brightos             # This is the name of the user that logs in automatically
+bos_user: brightos             # This is the name of the user that logs in automatically
 
 # OpenDNS FamilyShield addresses: 208.67.222.123, 208.67.220.123
 # FamilyShield is free and blocks adult content.

--- a/docs/Implementation plan.md
+++ b/docs/Implementation plan.md
@@ -87,7 +87,7 @@ Definition of done:
 
 #### 3. Complete protective DNS support for RedHat-family systems
 
-STATUS: Debian complete. Red Hat validation TODO.
+STATUS: COMPLETE.
 
 Why this matters:
 DNS controls are one of the few current mechanisms explicitly aimed at
@@ -117,6 +117,8 @@ Definition of done:
 ### P1: Restore feature parity for supported platforms
 
 #### 4. Add a RedHat-family Molecule scenario
+
+STATUS: COMPLETE.
 
 Why this matters:
 RedHat-specific verification and role logic cannot be trusted if they are never

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -425,11 +425,16 @@ make it optional. Instead, RedHat-family EL10 targets use a strict fallback:
 
 If either repo install or source fallback fails, the run fails.
 
-For VM-backed Molecule scenarios, the `prepare` and `converge` playbooks also
-clear inherited proxy environment variables while bootstrapping packages. This
-avoids stale `/etc/environment` proxy settings on reused VMs from breaking the
-package-manager steps that must run before the local Privoxy service is
-re-established.
+For VM-backed Molecule scenarios, proxy environment clearing in `prepare` and
+`converge` is now opt-in. By default, inherited proxy variables are preserved,
+which is safer for environments that require outbound proxies.
+
+If you need to neutralize stale proxy values on reused VMs, set
+`molecule_clear_proxy_env=true` for the run, for example:
+
+```bash
+scripts/molecule-vm-env.sh run almalinux -- test -s vm_almalinux -e molecule_clear_proxy_env=true
+```
 
 ### External package mirror intermittency
 

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -8,9 +8,11 @@ manual virtual machine configuration.
 
 ## Supported Execution Model
 
-Molecule runs tests in Docker containers using the default scenario:
+Molecule runs tests in Docker containers using these scenarios:
 - **Driver**: Docker
-- **Platform**: Ubuntu 24.04
+- **Platforms**:
+  - Ubuntu 24.04 (`default` scenario)
+  - AlmaLinux 9 (`almalinux9` scenario)
 - **Tests**: Syntax check, convergence, idempotence, verification
 
 The preferred approach (used by the project maintainer) is to test from a WSL2
@@ -70,6 +72,7 @@ ansible-galaxy collection install -r /path/to/BrightOS/requirements.yml
 ## Scenario Overview
 
 - `default`: Ubuntu Server 24.04 in Docker
+- `almalinux9`: AlmaLinux 9 in Docker
 
 Additional scenarios can be added by creating directories in `molecule/` with
 their own `molecule.yml` configurations.
@@ -82,21 +85,25 @@ From WSL, activate the venv and run Molecule:
 cd /path/to/BrightOS
 source ~/venv/brightos-test/bin/activate
 
-# Full test cycle
-molecule test
+# Full test cycle (default scenario)
+molecule test -s default
+
+# Full test cycle (RedHat-family scenario)
+molecule test -s almalinux9
 ```
 
 ## Step-by-Step Actions
 
-Run Molecule actions individually for debugging:
+Run Molecule actions individually for debugging (replace `default` with
+`almalinux9` to target the RedHat-family scenario):
 
 ```bash
-molecule converge     # Apply roles to container
-molecule create       # Create and start container
-molecule destroy      # Stop and remove container
-molecule idempotence  # Verify idempotent run
-molecule syntax       # Check playbook syntax
-molecule verify       # Run verify playbook
+molecule create -s default       # Create and start container
+molecule converge -s default     # Apply roles to container
+molecule idempotence -s default  # Verify idempotent run
+molecule syntax -s default       # Check playbook syntax
+molecule verify -s default       # Run verify playbook
+molecule destroy -s default      # Stop and remove container
 ```
 
 ## Verification Policy

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,10 +1,11 @@
 # Testing with Molecule
 
-This guide covers setup and execution of Molecule for the BrightOS Ansible playbook.
+This guide covers setup and execution of Molecule for the BrightOS Ansible
+playbook.
 
-Testing uses **Docker containers** with Molecule for fast, reproducible test
-cycles. This approach can work on Windows, macOS, and Linux without requiring
-manual virtual machine configuration.
+Playbooks are tested using Molecule. Testing is possible with Docker containers
+(for fast, reproducible test cycles) and user-built minimal VMs, for more
+thorough testing.
 
 ## Supported Execution Model
 
@@ -12,18 +13,47 @@ Molecule runs tests in Docker containers using these scenarios:
 - **Driver**: Docker
 - **Platforms**:
   - Ubuntu 24.04 (`default` scenario)
-  - AlmaLinux 9 (`almalinux9` scenario)
+  - AlmaLinux 10 (`almalinux` scenario)
 - **Tests**: Syntax check, convergence, idempotence, verification
 
+Molecule can also run against prebuilt VMs over SSH using VM scenarios:
+- `vm_ubuntu`: Ubuntu VM reachable over SSH
+- `vm_almalinux`: AlmaLinux VM reachable over SSH
+
+Use container scenarios for rapid iteration, then validate on VM scenarios
+before merge when changes affect host-level behaviour.
+
 The preferred approach (used by the project maintainer) is to test from a WSL2
-Linux environment with a Docker daemon running on Windows.
+Linux environment with a Docker daemon running on Windows, and then run VM tests
+against VMs built on ESXi. (The hypervisor choice is immaterial; the VMs are
+accessed via IP/SSH.)
+
+### Important Container Limitations
+
+Docker-based Molecule scenarios are excellent for fast role validation, but they
+cannot faithfully reproduce every host-level behaviour.
+
+Known limits in container scenarios include:
+
+- Service/runtime checks that rely on full init/systemd behaviour (for example,
+  `firewalld`, `snapd`, or service enablement semantics)
+- Network configuration paths where Docker manages files directly (for example,
+  `/etc/resolv.conf`)
+- Host identity operations that are restricted in containers (for example,
+  hostname changes)
+- Some GUI package installs that depend on kernel features, external mirrors,
+  or repository combinations not stable in minimal container images
+
+Because of these limits, Molecule assertions include container-aware guards in
+some areas. A passing container scenario means role logic is healthy for the
+tested paths, but it is not a complete substitute for full VM/system testing.
 
 ## Prerequisites
 
 Be sure to copy `config.yml.example` to `config.yml` and update any necessary
 configuration values before running tests.
 
-### System Requirements
+### Suggested System Requirements
 
 - Windows 10 or later
 - WSL2 installed and configured
@@ -46,7 +76,7 @@ docker ps
 
 ### Install Linux Tooling in WSL
 
-In WSL:
+In WSL (Ubuntu/Debian):
 
 ```bash
 sudo apt update && sudo apt -y upgrade
@@ -72,10 +102,39 @@ ansible-galaxy collection install -r /path/to/BrightOS/requirements.yml
 ## Scenario Overview
 
 - `default`: Ubuntu Server 24.04 in Docker
-- `almalinux9`: AlmaLinux 9 in Docker
+- `almalinux`: AlmaLinux in Docker
+- `vm_ubuntu`: prebuilt Ubuntu VM over SSH (default driver, unmanaged host)
+- `vm_almalinux`: prebuilt AlmaLinux VM over SSH (default driver, unmanaged
+  host)
 
 Additional scenarios can be added by creating directories in `molecule/` with
 their own `molecule.yml` configurations.
+
+## VM Quick Start
+
+If your VMs already exist and are reachable over SSH, this is the fastest path:
+
+```bash
+cd /path/to/BrightOS
+
+# Optional, but recommended when using the project-local Molecule install
+source .venv/bin/activate
+
+cp .molecule-vm.env.example .molecule-vm.env
+# Edit .molecule-vm.env with your VM hostnames/IPs and SSH key path
+
+# Run one VM target
+scripts/molecule-vm-env.sh run ubuntu
+scripts/molecule-vm-env.sh run almalinux
+
+# Or run both targets in parallel
+scripts/molecule-vm-env.sh run-both
+```
+
+Expected logs for parallel runs:
+
+- `.molecule-vm-logs/vm_ubuntu.log`
+- `.molecule-vm-logs/vm_almalinux.log`
 
 ## Running Tests
 
@@ -89,13 +148,25 @@ source ~/venv/brightos-test/bin/activate
 molecule test -s default
 
 # Full test cycle (RedHat-family scenario)
-molecule test -s almalinux9
+molecule test -s almalinux
+
+# Full test cycle against a prebuilt Ubuntu VM over SSH
+MOLECULE_VM_HOST=192.0.2.10 \
+MOLECULE_VM_USER=brightos \
+MOLECULE_VM_KEY=~/.ssh/id_ed25519 \
+molecule test -s vm_ubuntu
+
+# Full test cycle against a prebuilt AlmaLinux VM over SSH
+MOLECULE_VM_HOST=192.0.2.20 \
+MOLECULE_VM_USER=brightos \
+MOLECULE_VM_KEY=~/.ssh/id_ed25519 \
+molecule test -s vm_almalinux
 ```
 
 ## Step-by-Step Actions
 
 Run Molecule actions individually for debugging (replace `default` with
-`almalinux9` to target the RedHat-family scenario):
+`almalinux` to target the RedHat-family scenario):
 
 ```bash
 molecule create -s default       # Create and start container
@@ -106,12 +177,182 @@ molecule verify -s default       # Run verify playbook
 molecule destroy -s default      # Stop and remove container
 ```
 
+For VM-over-SSH scenarios, `create`/`destroy` are intentionally not part of
+the test sequence because Molecule does not manage VM lifecycle.
+
+## VM Scenarios (SSH to Prebuilt Machines)
+
+Use these scenarios when you need host-accurate validation for firewall,
+network, service startup, and GUI/package behaviour that containers cannot
+fully represent.
+
+### Helper Script (Recommended)
+
+To switch between Ubuntu and AlmaLinux VM targets with one command:
+
+1. Copy the template and edit values:
+
+```bash
+cp .molecule-vm.env.example .molecule-vm.env
+```
+
+2. Load the target in your current shell:
+
+```bash
+source scripts/molecule-vm-env.sh ubuntu
+# or
+source scripts/molecule-vm-env.sh almalinux
+```
+
+3. Run Molecule using the selected scenario:
+
+```bash
+molecule test -s "$MOLECULE_VM_SCENARIO"
+```
+
+If you prefer not to modify the current shell, the helper can also run the
+test directly:
+
+```bash
+scripts/molecule-vm-env.sh run ubuntu
+scripts/molecule-vm-env.sh run almalinux
+```
+
+The script exports:
+
+- `MOLECULE_VM_HOST`
+- `MOLECULE_VM_USER`
+- `MOLECULE_VM_PORT`
+- `MOLECULE_VM_KEY`
+- `MOLECULE_VM_SSH_COMMON_ARGS`
+- `MOLECULE_VM_SCENARIO`
+
+By default it reads `.molecule-vm.env`. You can pass a custom env file path:
+
+```bash
+source scripts/molecule-vm-env.sh ubuntu /path/to/custom.env
+```
+
+### Running Both VM Tests In Parallel
+
+If you already have both VMs built and reachable, the simplest approach is to
+launch both Molecule runs at once and let each write to its own log file:
+
+```bash
+scripts/molecule-vm-env.sh run-both
+```
+
+That starts these two full test runs concurrently:
+
+- `molecule test -s vm_ubuntu`
+- `molecule test -s vm_almalinux`
+
+The helper resolves Molecule in this order:
+
+- `MOLECULE_BIN` if set
+- `.venv/bin/molecule` in the current repository
+- first `molecule` found on `PATH`
+
+If your system Molecule differs from your project venv, either activate the
+venv first or set `MOLECULE_BIN` explicitly, for example:
+
+```bash
+export MOLECULE_BIN=/repos/BrightOS/.venv/bin/molecule
+scripts/molecule-vm-env.sh run-both
+```
+
+Logs are written to:
+
+- `.molecule-vm-logs/vm_ubuntu.log`
+- `.molecule-vm-logs/vm_almalinux.log`
+
+The helper waits for both jobs to finish and returns a non-zero exit code if
+either scenario fails.
+
+If you want to inspect one target manually in parallel-friendly subshells, you
+can also use the `print` mode:
+
+```bash
+( eval "$(scripts/molecule-vm-env.sh print ubuntu)" && molecule test -s "$MOLECULE_VM_SCENARIO" ) &
+( eval "$(scripts/molecule-vm-env.sh print almalinux)" && molecule test -s "$MOLECULE_VM_SCENARIO" ) &
+wait
+```
+
+Suggested use:
+
+- Use `run-both` for routine regression runs.
+- Use `run` or `print` when you want to debug one VM or customise the command.
+
+### Required Environment Variables
+
+Set these when running `vm_ubuntu` or `vm_almalinux10`:
+
+- `MOLECULE_VM_HOST`: VM IP address (preferred — see note below) or DNS name
+- `MOLECULE_VM_USER`: SSH username (defaults to `brightos` if omitted)
+- `MOLECULE_VM_KEY`: path to private SSH key for that user
+
+Optional:
+
+- `MOLECULE_VM_PORT`: SSH port (default `22`)
+- `MOLECULE_VM_SSH_COMMON_ARGS`: extra SSH args (default uses
+    `-o StrictHostKeyChecking=accept-new`)
+
+Example:
+
+```bash
+export MOLECULE_VM_HOST=192.0.2.10
+export MOLECULE_VM_USER=brightos
+export MOLECULE_VM_KEY=~/.ssh/id_ed25519
+export MOLECULE_VM_PORT=22
+
+molecule test -s vm_ubuntu
+```
+
+### Vanilla VM Build Baseline
+
+> **DNS note when running VM scenarios:** The `name` role sets the system
+> hostname. If `system_hostname` is not defined in `config.yml`, the role
+> defaults to preserving the current hostname (a no-op). If you *do* set
+> `system_hostname` to a different value, DHCP/dynamic DNS will re-register the
+> machine under the new name after the post-SELinux reboot, making the original
+> hostname unresolvable and breaking Ansible's reconnect. To avoid this during
+> testing, either leave `system_hostname` unset, set it to the VM's actual
+> hostname, or use IP addresses for `MOLECULE_VM_HOST`.
+
+Build from a clean image/snapshot each run where practical.
+
+Ubuntu baseline:
+
+- Install Ubuntu Server 24.04 (minimal is fine)
+- Enable SSH server
+- Create user `brightos` (or set `MOLECULE_VM_USER` to your chosen account)
+- Add your public key to `~/.ssh/authorized_keys`
+- Grant passwordless sudo for the SSH user
+- Ensure Python 3 is present (`python3`)
+
+AlmaLinux baseline:
+
+- Install AlmaLinux 10 (minimal is fine)
+- Enable SSH server
+- Create user `brightos` (or set `MOLECULE_VM_USER` to your chosen account)
+- Add your public key to `~/.ssh/authorized_keys`
+- Grant passwordless sudo for the SSH user
+- Ensure Python 3 is present (`python3`)
+
+Recommended preflight before running Molecule:
+
+```bash
+ssh -i ~/.ssh/id_ed25519 brightos@192.0.2.10 'python3 --version && sudo -n true'
+```
+
 ## Verification Policy
 
-The verify playbook now checks more than simple package presence. It asserts a
-set of safety and accessibility outcomes including firewall state, DNS-related
-configuration, proxy enforcement, browser policy, GNOME lockdown settings, and
-application visibility policy.
+The verify playbook asserts a set of safety and accessibility outcomes including
+firewall state, DNS-related configuration, proxy enforcement, browser policy,
+GNOME lockdown settings, and application visibility policy. Where container
+behaviour differs from real hosts, verification tasks are intentionally
+scoped/guarded so tests remain meaningful instead of failing for container-only
+constraints.
 
 Application visibility and allow/deny checks are driven by variables in
 [config.yml.example](../config.yml.example):
@@ -153,6 +394,58 @@ will fail until enforcement tasks are added. Update
 only when the verification semantics themselves need to change.
 
 ## Troubleshooting
+
+### VM run fails after host reboot step
+
+If a VM run fails to reconnect after reboot, verify that your VM hostname
+remains resolvable throughout the run. This can happen when DHCP/DNS
+re-registration changes after hostname updates.
+
+Recommended mitigations:
+
+1. Keep `system_hostname` unset in `config.yml` unless you explicitly need to
+    change it.
+2. If you set `system_hostname`, keep `MOLECULE_VM_HOST` aligned with the name
+    your DNS actually serves after reboot.
+3. Use VM IPs in `.molecule-vm.env` if your DNS is dynamic or intermittent.
+
+### AlmaLinux 10 proxy package availability
+
+On AlmaLinux 10, `privoxy` is not currently available in the default enabled
+repositories used by this project (including EPEL 10 and EPEL testing).
+
+Because Privoxy is part of BrightOS safety guarantees, the role does **not**
+make it optional. Instead, RedHat-family EL10 targets use a strict fallback:
+
+1. Attempt repo-based install (`dnf install privoxy`)
+2. If unavailable, build and install PCRE 8 from upstream source
+3. Build and install Privoxy from upstream source
+4. Install the required Privoxy action/filter files and register a
+    `privoxy.service` unit
+
+If either repo install or source fallback fails, the run fails.
+
+For VM-backed Molecule scenarios, the `prepare` and `converge` playbooks also
+clear inherited proxy environment variables while bootstrapping packages. This
+avoids stale `/etc/environment` proxy settings on reused VMs from breaking the
+package-manager steps that must run before the local Privoxy service is
+re-established.
+
+### External package mirror intermittency
+
+Some optional GUI package sources (for example, Tux Paint release RPM sources)
+can be intermittently unavailable from certain networks. The role rescues these
+download failures and continues so the scenario can still validate the rest of
+the system state.
+
+### Converge output shows `fatal` before recovery
+
+In Ansible `block`/`rescue` flows, a task may show a `fatal` line and then be
+recovered by a rescue task in the same role. Treat final scenario status as
+authoritative:
+
+- Scenario pass: Molecule exits with code `0`
+- Scenario fail: Molecule exits non-zero and reports a failed action
 
 ### Docker daemon not accessible
 
@@ -201,6 +494,17 @@ Docker on Windows (via WSL2) can be slower than native Linux Docker. Consider:
 - Closing unused applications to free memory
 - Increasing Docker Desktop memory allocation (Settings → Resources → Memory)
 - Running tests during off-peak machine usage
+
+### When container tests are not enough
+
+Use container scenarios for fast feedback during development, then run at least
+one full validation pass on a VM (or real host) before merge/release whenever
+your change touches:
+
+- Firewall runtime behaviour
+- Network manager/resolver behaviour
+- GUI stack/package completeness
+- Service enablement/startup semantics
 
 ## Advanced Usage
 

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -285,7 +285,7 @@ Suggested use:
 
 ### Required Environment Variables
 
-Set these when running `vm_ubuntu` or `vm_almalinux10`:
+Set these when running `vm_ubuntu` or `vm_almalinux`:
 
 - `MOLECULE_VM_HOST`: VM IP address (preferred — see note below) or DNS name
 - `MOLECULE_VM_USER`: SSH username (defaults to `brightos` if omitted)

--- a/inventory.example
+++ b/inventory.example
@@ -1,5 +1,5 @@
 [targets]
 # Amend as required, based on the host[s] you're configuring, and rename this
 # file to "inventory".
-snl-al9.yourlan.yourdomain system_hostname=snl-al9
-snl-u22.yourlan.yourdomain system_hostname=snl-u22
+brightos-al10.yourlan.yourdomain system_hostname=brightos-al10
+brightos-ub24.yourlan.yourdomain system_hostname=brightos-ub24

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -1,18 +1,30 @@
 # Testing with Molecule
 
-This directory contains Molecule test scenarios for the BrightOS playbook. The
-default scenario uses Docker containers to test the playbook in an isolated,
-reproducible environment. This approach works on Windows, macOS, and Linux
-without requiring Hyper-V or virtual machine configuration.
+This directory contains Molecule test scenarios for the BrightOS playbook.
+Container scenarios provide fast, reproducible checks, and VM-over-SSH
+scenarios can target prebuilt machines for host-accurate validation.
 
 ## Available Scenarios
 
-- **`default`** — Ubuntu Server 24.04 (recommended for most development)
+- **`default`** — Ubuntu Server 24.04 in Docker
+- **`almalinux`** — AlmaLinux 10 in Docker
+- **`vm_ubuntu`** — prebuilt Ubuntu VM over SSH (default driver, unmanaged host)
+- **`vm_almalinux`** — prebuilt AlmaLinux 10 VM over SSH (default driver, unmanaged host)
 
 ## Getting Started
 
 See **[../docs/Testing.md](../docs/Testing.md)** for comprehensive setup and
 usage instructions.
+
+For VM-over-SSH scenarios, use **[../scripts/molecule-vm-env.sh](../scripts/molecule-vm-env.sh)**
+with **[../.molecule-vm.env.example](../.molecule-vm.env.example)** to switch
+targets quickly.
+
+For a full parallel VM regression run, use:
+
+```bash
+scripts/molecule-vm-env.sh run-both
+```
 
 This includes:
 - Prerequisites and software installation
@@ -28,4 +40,4 @@ Each scenario directory contains:
 Shared playbooks live in `resources/playbooks/`:
 - `prepare.yml` — pre-convergence setup (e.g., install GNOME dependencies)
 - `converge.yml` — main playbook execution
-- `verify.yml` — post-convergence assertions (currently minimal)
+- `verify.yml` — post-convergence assertions

--- a/molecule/almalinux/molecule.yml
+++ b/molecule/almalinux/molecule.yml
@@ -10,7 +10,7 @@ lint: |
   ansible-lint -x no-loop-var-prefix,command-instead-of-module,package-latest
 platforms:
   - name: vm-runner
-    image: almalinux:9
+    image: almalinux:10
     pre_build_image: false
     command: /bin/bash -c 'while true; do sleep 1; done'
     privileged: true

--- a/molecule/almalinux9/molecule.yml
+++ b/molecule/almalinux9/molecule.yml
@@ -1,0 +1,28 @@
+---
+dependency:
+  name: galaxy
+  enabled: false
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint -x no-loop-var-prefix,command-instead-of-module,package-latest
+platforms:
+  - name: vm-runner
+    image: almalinux:9
+    pre_build_image: false
+    command: /bin/bash -c 'while true; do sleep 1; done'
+    privileged: true
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_ROLES_PATH: "../../roles"
+  playbooks:
+    cleanup: ../resources/playbooks/cleanup.yml
+    converge: ../resources/playbooks/converge.yml
+    prepare: ../resources/playbooks/prepare.yml
+    verify: ../resources/playbooks/verify.yml
+verifier:
+  name: ansible

--- a/molecule/resources/playbooks/converge.yml
+++ b/molecule/resources/playbooks/converge.yml
@@ -5,13 +5,14 @@
     - "../../../config.yml"
   vars:
     _molecule_clear_proxy_env: "{{ molecule_clear_proxy_env | default(false) | bool }}"
-  environment:
-    http_proxy: "{{ '' if _molecule_clear_proxy_env else omit }}"
-    https_proxy: "{{ '' if _molecule_clear_proxy_env else omit }}"
-    HTTP_PROXY: "{{ '' if _molecule_clear_proxy_env else omit }}"
-    HTTPS_PROXY: "{{ '' if _molecule_clear_proxy_env else omit }}"
-    no_proxy: "{{ '' if _molecule_clear_proxy_env else omit }}"
-    NO_PROXY: "{{ '' if _molecule_clear_proxy_env else omit }}"
+    _molecule_clear_proxy_env_vars:
+      http_proxy: ""
+      https_proxy: ""
+      HTTP_PROXY: ""
+      HTTPS_PROXY: ""
+      no_proxy: ""
+      NO_PROXY: ""
+  environment: "{{ _molecule_clear_proxy_env_vars if _molecule_clear_proxy_env else {} }}"
   pre_tasks:
     - name: update apt cache
       ansible.builtin.apt:

--- a/molecule/resources/playbooks/converge.yml
+++ b/molecule/resources/playbooks/converge.yml
@@ -3,13 +3,15 @@
   hosts: all
   vars_files:
     - "../../../config.yml"
+  vars:
+    molecule_clear_proxy_env: "{{ molecule_clear_proxy_env | default(false) | bool }}"
   environment:
-    http_proxy: ""
-    https_proxy: ""
-    HTTP_PROXY: ""
-    HTTPS_PROXY: ""
-    no_proxy: ""
-    NO_PROXY: ""
+    http_proxy: "{{ '' if molecule_clear_proxy_env else omit }}"
+    https_proxy: "{{ '' if molecule_clear_proxy_env else omit }}"
+    HTTP_PROXY: "{{ '' if molecule_clear_proxy_env else omit }}"
+    HTTPS_PROXY: "{{ '' if molecule_clear_proxy_env else omit }}"
+    no_proxy: "{{ '' if molecule_clear_proxy_env else omit }}"
+    NO_PROXY: "{{ '' if molecule_clear_proxy_env else omit }}"
   pre_tasks:
     - name: update apt cache
       ansible.builtin.apt:

--- a/molecule/resources/playbooks/converge.yml
+++ b/molecule/resources/playbooks/converge.yml
@@ -3,6 +3,13 @@
   hosts: all
   vars_files:
     - "../../../config.yml"
+  environment:
+    http_proxy: ""
+    https_proxy: ""
+    HTTP_PROXY: ""
+    HTTPS_PROXY: ""
+    no_proxy: ""
+    NO_PROXY: ""
   pre_tasks:
     - name: update apt cache
       ansible.builtin.apt:

--- a/molecule/resources/playbooks/converge.yml
+++ b/molecule/resources/playbooks/converge.yml
@@ -4,14 +4,14 @@
   vars_files:
     - "../../../config.yml"
   vars:
-    molecule_clear_proxy_env: "{{ molecule_clear_proxy_env | default(false) | bool }}"
+    _molecule_clear_proxy_env: "{{ molecule_clear_proxy_env | default(false) | bool }}"
   environment:
-    http_proxy: "{{ '' if molecule_clear_proxy_env else omit }}"
-    https_proxy: "{{ '' if molecule_clear_proxy_env else omit }}"
-    HTTP_PROXY: "{{ '' if molecule_clear_proxy_env else omit }}"
-    HTTPS_PROXY: "{{ '' if molecule_clear_proxy_env else omit }}"
-    no_proxy: "{{ '' if molecule_clear_proxy_env else omit }}"
-    NO_PROXY: "{{ '' if molecule_clear_proxy_env else omit }}"
+    http_proxy: "{{ '' if _molecule_clear_proxy_env else omit }}"
+    https_proxy: "{{ '' if _molecule_clear_proxy_env else omit }}"
+    HTTP_PROXY: "{{ '' if _molecule_clear_proxy_env else omit }}"
+    HTTPS_PROXY: "{{ '' if _molecule_clear_proxy_env else omit }}"
+    no_proxy: "{{ '' if _molecule_clear_proxy_env else omit }}"
+    NO_PROXY: "{{ '' if _molecule_clear_proxy_env else omit }}"
   pre_tasks:
     - name: update apt cache
       ansible.builtin.apt:

--- a/molecule/resources/playbooks/prepare.yml
+++ b/molecule/resources/playbooks/prepare.yml
@@ -1,13 +1,15 @@
 ---
 - name: Prepare
   hosts: all
+  vars:
+    molecule_clear_proxy_env: "{{ molecule_clear_proxy_env | default(false) | bool }}"
   environment:
-    http_proxy: ""
-    https_proxy: ""
-    HTTP_PROXY: ""
-    HTTPS_PROXY: ""
-    no_proxy: ""
-    NO_PROXY: ""
+    http_proxy: "{{ '' if molecule_clear_proxy_env else omit }}"
+    https_proxy: "{{ '' if molecule_clear_proxy_env else omit }}"
+    HTTP_PROXY: "{{ '' if molecule_clear_proxy_env else omit }}"
+    HTTPS_PROXY: "{{ '' if molecule_clear_proxy_env else omit }}"
+    no_proxy: "{{ '' if molecule_clear_proxy_env else omit }}"
+    NO_PROXY: "{{ '' if molecule_clear_proxy_env else omit }}"
   tasks:
     - name: install Gnome & dconf
       ansible.builtin.apt:

--- a/molecule/resources/playbooks/prepare.yml
+++ b/molecule/resources/playbooks/prepare.yml
@@ -2,14 +2,14 @@
 - name: Prepare
   hosts: all
   vars:
-    molecule_clear_proxy_env: "{{ molecule_clear_proxy_env | default(false) | bool }}"
+    _molecule_clear_proxy_env: "{{ molecule_clear_proxy_env | default(false) | bool }}"
   environment:
-    http_proxy: "{{ '' if molecule_clear_proxy_env else omit }}"
-    https_proxy: "{{ '' if molecule_clear_proxy_env else omit }}"
-    HTTP_PROXY: "{{ '' if molecule_clear_proxy_env else omit }}"
-    HTTPS_PROXY: "{{ '' if molecule_clear_proxy_env else omit }}"
-    no_proxy: "{{ '' if molecule_clear_proxy_env else omit }}"
-    NO_PROXY: "{{ '' if molecule_clear_proxy_env else omit }}"
+    http_proxy: "{{ '' if _molecule_clear_proxy_env else omit }}"
+    https_proxy: "{{ '' if _molecule_clear_proxy_env else omit }}"
+    HTTP_PROXY: "{{ '' if _molecule_clear_proxy_env else omit }}"
+    HTTPS_PROXY: "{{ '' if _molecule_clear_proxy_env else omit }}"
+    no_proxy: "{{ '' if _molecule_clear_proxy_env else omit }}"
+    NO_PROXY: "{{ '' if _molecule_clear_proxy_env else omit }}"
   tasks:
     - name: install Gnome & dconf
       ansible.builtin.apt:

--- a/molecule/resources/playbooks/prepare.yml
+++ b/molecule/resources/playbooks/prepare.yml
@@ -3,13 +3,14 @@
   hosts: all
   vars:
     _molecule_clear_proxy_env: "{{ molecule_clear_proxy_env | default(false) | bool }}"
-  environment:
-    http_proxy: "{{ '' if _molecule_clear_proxy_env else omit }}"
-    https_proxy: "{{ '' if _molecule_clear_proxy_env else omit }}"
-    HTTP_PROXY: "{{ '' if _molecule_clear_proxy_env else omit }}"
-    HTTPS_PROXY: "{{ '' if _molecule_clear_proxy_env else omit }}"
-    no_proxy: "{{ '' if _molecule_clear_proxy_env else omit }}"
-    NO_PROXY: "{{ '' if _molecule_clear_proxy_env else omit }}"
+    _molecule_clear_proxy_env_vars:
+      http_proxy: ""
+      https_proxy: ""
+      HTTP_PROXY: ""
+      HTTPS_PROXY: ""
+      no_proxy: ""
+      NO_PROXY: ""
+  environment: "{{ _molecule_clear_proxy_env_vars if _molecule_clear_proxy_env else {} }}"
   tasks:
     - name: install Gnome & dconf
       ansible.builtin.apt:

--- a/molecule/resources/playbooks/prepare.yml
+++ b/molecule/resources/playbooks/prepare.yml
@@ -1,6 +1,13 @@
 ---
 - name: Prepare
   hosts: all
+  environment:
+    http_proxy: ""
+    https_proxy: ""
+    HTTP_PROXY: ""
+    HTTPS_PROXY: ""
+    no_proxy: ""
+    NO_PROXY: ""
   tasks:
     - name: install Gnome & dconf
       ansible.builtin.apt:

--- a/molecule/resources/playbooks/prepare.yml
+++ b/molecule/resources/playbooks/prepare.yml
@@ -14,10 +14,9 @@
       become: true
       when: ansible_facts['os_family'] == 'Debian'
 
-    - name: install Gnome & dconf
+    - name: install dconf tools (RedHat)
       ansible.builtin.dnf:
         name: [
-          "gnome-core",
           "dconf",
           "dconf-editor",
         ]

--- a/molecule/resources/playbooks/verify.yml
+++ b/molecule/resources/playbooks/verify.yml
@@ -319,6 +319,8 @@
       ansible.builtin.slurp:
         src: /etc/environment
       register: environment_content
+      when:
+        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
     - name: Assert system-wide HTTP proxy is enforced via /etc/environment
       ansible.builtin.assert:

--- a/molecule/resources/playbooks/verify.yml
+++ b/molecule/resources/playbooks/verify.yml
@@ -226,19 +226,25 @@
       ansible.builtin.stat:
         path: /etc/NetworkManager/NetworkManager.conf
       register: networkmanager_conf
-      when: ansible_facts['os_family'] == "RedHat"
+      when:
+        - ansible_facts['os_family'] == "RedHat"
+        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
     - name: Assert NetworkManager.conf exists (RedHat)
       ansible.builtin.assert:
         that: networkmanager_conf.stat.exists
         fail_msg: "/etc/NetworkManager/NetworkManager.conf does not exist"
-      when: ansible_facts['os_family'] == "RedHat"
+      when:
+        - ansible_facts['os_family'] == "RedHat"
+        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
     - name: Read NetworkManager.conf (RedHat)
       ansible.builtin.slurp:
         src: /etc/NetworkManager/NetworkManager.conf
       register: networkmanager_conf_content
-      when: ansible_facts['os_family'] == "RedHat"
+      when:
+        - ansible_facts['os_family'] == "RedHat"
+        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
     - name: Assert NetworkManager DNS management is disabled (RedHat)
       ansible.builtin.assert:
@@ -248,7 +254,9 @@
         fail_msg: >
           /etc/NetworkManager/NetworkManager.conf does not disable
           NetworkManager DNS management with dns=none
-      when: ansible_facts['os_family'] == "RedHat"
+      when:
+        - ansible_facts['os_family'] == "RedHat"
+        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
     # =========================================================================
     # Proxy (Privoxy) configuration and enforcement

--- a/molecule/resources/playbooks/verify.yml
+++ b/molecule/resources/playbooks/verify.yml
@@ -31,6 +31,11 @@
       ansible.builtin.package_facts:
         manager: auto
 
+    - name: Check whether privoxy binary exists
+      ansible.builtin.stat:
+        path: /usr/sbin/privoxy
+      register: privoxy_binary
+
     - name: Assert firewall package is present (Debian)
       ansible.builtin.assert:
         that: "'ufw' in ansible_facts.packages"
@@ -45,7 +50,8 @@
 
     - name: Assert proxy package is present
       ansible.builtin.assert:
-        that: "'privoxy' in ansible_facts.packages"
+        that:
+          - "'privoxy' in ansible_facts.packages or privoxy_binary.stat.exists"
         fail_msg: "privoxy is not installed"
 
     - name: Assert required accessible desktop packages are present (Debian)
@@ -145,7 +151,7 @@
       ansible.builtin.assert:
         that:
           - firewalld_services.rc == 0
-          - "'ssh' in firewalld_services.stdout.split()"        
+          - "'ssh' in firewalld_services.stdout.split()"
         fail_msg: >
           firewalld does not allow the required SSH service
       when:
@@ -312,7 +318,8 @@
         fail_msg: >
           System-wide HTTP proxy is not set in /etc/environment — applications
           may bypass content filtering
-      when: ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+      when:
+        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
     # =========================================================================
     # Firefox policy enforcement
@@ -376,9 +383,9 @@
 
     - name: Assert automatic login is for the correct user
       ansible.builtin.assert:
-        that: "('AutomaticLogin=' ~ snl_user) in (gdm_content.content | b64decode)"
+        that: "('AutomaticLogin=' ~ bos_user) in (gdm_content.content | b64decode)"
         fail_msg: >
-          AutomaticLogin is not set to '{{ snl_user }}' in /etc/gdm3/custom.conf
+          AutomaticLogin is not set to '{{ bos_user }}' in /etc/gdm3/custom.conf
       when: ansible_facts['os_family'] == "Debian"
 
     - name: Check gnome-initial-setup suppression file exists
@@ -567,5 +574,5 @@
             requires a VM-backed scenario with a running graphical session.
           - SELinux enforcing state on Debian: reboot-dependent and not achievable
             in a Docker container environment.
-          - RedHat DNS override (/etc/NetworkManager/...): no RedHat Molecule
-            scenario exists yet; tracked as plan item 3.
+          - Some runtime service states in container scenarios are intentionally
+            validated via config/unit presence rather than live init-system state.

--- a/molecule/resources/playbooks/verify.yml
+++ b/molecule/resources/playbooks/verify.yml
@@ -5,6 +5,8 @@
   become: true
   vars_files:
     - "../../../config.yml"
+  vars:
+    molecule_is_container: "{{ ansible_facts['virtualization_type'] is defined and ansible_facts['virtualization_type'] in ['docker', 'containerd', 'podman'] }}"
 
   tasks:
 
@@ -125,7 +127,7 @@
       failed_when: false
       when:
         - ansible_facts['os_family'] == "RedHat"
-        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+        - not molecule_is_container
 
     - name: Assert firewalld is active (RedHat)
       ansible.builtin.assert:
@@ -136,7 +138,7 @@
           firewalld is not running - the firewall is installed but not active
       when:
         - ansible_facts['os_family'] == "RedHat"
-        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+        - not molecule_is_container
 
     - name: Read firewalld allowed services (RedHat)
       ansible.builtin.command: firewall-cmd --list-services
@@ -145,7 +147,7 @@
       failed_when: false
       when:
         - ansible_facts['os_family'] == "RedHat"
-        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+        - not molecule_is_container
 
     - name: Assert firewalld allows SSH (RedHat)
       ansible.builtin.assert:
@@ -156,7 +158,7 @@
           firewalld does not allow the required SSH service
       when:
         - ansible_facts['os_family'] == "RedHat"
-        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+        - not molecule_is_container
 
     # =========================================================================
     # Protective DNS configuration
@@ -194,7 +196,7 @@
       register: resolv_conf
       when:
         - ansible_facts['os_family'] == "RedHat"
-        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+        - not molecule_is_container
 
     - name: Assert /etc/resolv.conf exists (RedHat)
       ansible.builtin.assert:
@@ -202,7 +204,7 @@
         fail_msg: "/etc/resolv.conf does not exist"
       when:
         - ansible_facts['os_family'] == "RedHat"
-        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+        - not molecule_is_container
 
     - name: Read /etc/resolv.conf (RedHat)
       ansible.builtin.slurp:
@@ -210,7 +212,7 @@
       register: resolv_conf_content
       when:
         - ansible_facts['os_family'] == "RedHat"
-        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+        - not molecule_is_container
 
     - name: Assert protective DNS server is configured in resolv.conf (RedHat)
       ansible.builtin.assert:
@@ -220,7 +222,7 @@
           /etc/resolv.conf — vulnerable users may use unprotected DNS
       when:
         - ansible_facts['os_family'] == "RedHat"
-        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+        - not molecule_is_container
 
     - name: Check NetworkManager.conf exists (RedHat)
       ansible.builtin.stat:
@@ -228,7 +230,7 @@
       register: networkmanager_conf
       when:
         - ansible_facts['os_family'] == "RedHat"
-        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+        - not molecule_is_container
 
     - name: Assert NetworkManager.conf exists (RedHat)
       ansible.builtin.assert:
@@ -236,7 +238,7 @@
         fail_msg: "/etc/NetworkManager/NetworkManager.conf does not exist"
       when:
         - ansible_facts['os_family'] == "RedHat"
-        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+        - not molecule_is_container
 
     - name: Read NetworkManager.conf (RedHat)
       ansible.builtin.slurp:
@@ -244,7 +246,7 @@
       register: networkmanager_conf_content
       when:
         - ansible_facts['os_family'] == "RedHat"
-        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+        - not molecule_is_container
 
     - name: Assert NetworkManager DNS management is disabled (RedHat)
       ansible.builtin.assert:
@@ -256,7 +258,7 @@
           NetworkManager DNS management with dns=none
       when:
         - ansible_facts['os_family'] == "RedHat"
-        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+        - not molecule_is_container
 
     # =========================================================================
     # Proxy (Privoxy) configuration and enforcement
@@ -319,8 +321,7 @@
       ansible.builtin.slurp:
         src: /etc/environment
       register: environment_content
-      when:
-        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+      when: not molecule_is_container
 
     - name: Assert system-wide HTTP proxy is enforced via /etc/environment
       ansible.builtin.assert:
@@ -328,8 +329,7 @@
         fail_msg: >
           System-wide HTTP proxy is not set in /etc/environment — applications
           may bypass content filtering
-      when:
-        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+      when: not molecule_is_container
 
     # =========================================================================
     # Firefox policy enforcement

--- a/molecule/resources/playbooks/verify.yml
+++ b/molecule/resources/playbooks/verify.yml
@@ -117,7 +117,9 @@
       register: firewalld_state
       changed_when: false
       failed_when: false
-      when: ansible_facts['os_family'] == "RedHat"
+      when:
+        - ansible_facts['os_family'] == "RedHat"
+        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
     - name: Assert firewalld is active (RedHat)
       ansible.builtin.assert:
@@ -126,14 +128,18 @@
           - firewalld_state.stdout == 'running'
         fail_msg: >
           firewalld is not running - the firewall is installed but not active
-      when: ansible_facts['os_family'] == "RedHat"
+      when:
+        - ansible_facts['os_family'] == "RedHat"
+        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
     - name: Read firewalld allowed services (RedHat)
       ansible.builtin.command: firewall-cmd --list-services
       register: firewalld_services
       changed_when: false
       failed_when: false
-      when: ansible_facts['os_family'] == "RedHat"
+      when:
+        - ansible_facts['os_family'] == "RedHat"
+        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
     - name: Assert firewalld allows SSH (RedHat)
       ansible.builtin.assert:
@@ -142,7 +148,9 @@
           - "'ssh' in firewalld_services.stdout.split()"        
         fail_msg: >
           firewalld does not allow the required SSH service
-      when: ansible_facts['os_family'] == "RedHat"
+      when:
+        - ansible_facts['os_family'] == "RedHat"
+        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
     # =========================================================================
     # Protective DNS configuration
@@ -178,19 +186,25 @@
       ansible.builtin.stat:
         path: /etc/resolv.conf
       register: resolv_conf
-      when: ansible_facts['os_family'] == "RedHat"
+      when:
+        - ansible_facts['os_family'] == "RedHat"
+        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
     - name: Assert /etc/resolv.conf exists (RedHat)
       ansible.builtin.assert:
         that: resolv_conf.stat.exists
         fail_msg: "/etc/resolv.conf does not exist"
-      when: ansible_facts['os_family'] == "RedHat"
+      when:
+        - ansible_facts['os_family'] == "RedHat"
+        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
     - name: Read /etc/resolv.conf (RedHat)
       ansible.builtin.slurp:
         src: /etc/resolv.conf
       register: resolv_conf_content
-      when: ansible_facts['os_family'] == "RedHat"
+      when:
+        - ansible_facts['os_family'] == "RedHat"
+        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
     - name: Assert protective DNS server is configured in resolv.conf (RedHat)
       ansible.builtin.assert:
@@ -198,7 +212,9 @@
         fail_msg: >
           Protective DNS server {{ dns_servers[0] }} is not present in
           /etc/resolv.conf — vulnerable users may use unprotected DNS
-      when: ansible_facts['os_family'] == "RedHat"
+      when:
+        - ansible_facts['os_family'] == "RedHat"
+        - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
     - name: Check NetworkManager.conf exists (RedHat)
       ansible.builtin.stat:
@@ -296,6 +312,7 @@
         fail_msg: >
           System-wide HTTP proxy is not set in /etc/environment — applications
           may bypass content filtering
+      when: ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
     # =========================================================================
     # Firefox policy enforcement

--- a/molecule/vm_almalinux/molecule.yml
+++ b/molecule/vm_almalinux/molecule.yml
@@ -1,0 +1,43 @@
+---
+dependency:
+  name: galaxy
+  enabled: false
+driver:
+  name: default
+lint: |
+  set -e
+  yamllint .
+  ansible-lint -x no-loop-var-prefix,command-instead-of-module,package-latest
+scenario:
+  test_sequence:
+    - dependency
+    - cleanup
+    - prepare
+    - converge
+    - idempotence
+    - verify
+platforms:
+  - name: vm-runner
+    managed: false
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_ROLES_PATH: "../../roles"
+  inventory:
+    host_vars:
+      vm-runner:
+        ansible_host: "{{ lookup('env', 'MOLECULE_VM_HOST') }}"
+        ansible_user: "{{ lookup('env', 'MOLECULE_VM_USER') | default('brightos', true) }}"
+        ansible_port: "{{ lookup('env', 'MOLECULE_VM_PORT') | default('22', true) }}"
+        ansible_ssh_private_key_file: "{{ lookup('env', 'MOLECULE_VM_KEY') }}"
+        ansible_ssh_common_args: "{{ lookup('env', 'MOLECULE_VM_SSH_COMMON_ARGS') | default('-o StrictHostKeyChecking=accept-new', true) }}"
+        ansible_python_interpreter: /usr/bin/python3
+        ansible_become: true
+  playbooks:
+    cleanup: ../resources/playbooks/cleanup.yml
+    converge: ../resources/playbooks/converge.yml
+    prepare: ../resources/playbooks/prepare.yml
+    verify: ../resources/playbooks/verify.yml
+verifier:
+  name: ansible

--- a/molecule/vm_ubuntu/molecule.yml
+++ b/molecule/vm_ubuntu/molecule.yml
@@ -1,0 +1,43 @@
+---
+dependency:
+  name: galaxy
+  enabled: false
+driver:
+  name: default
+lint: |
+  set -e
+  yamllint .
+  ansible-lint -x no-loop-var-prefix,command-instead-of-module,package-latest
+scenario:
+  test_sequence:
+    - dependency
+    - cleanup
+    - prepare
+    - converge
+    - idempotence
+    - verify
+platforms:
+  - name: vm-runner
+    managed: false
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_ROLES_PATH: "../../roles"
+  inventory:
+    host_vars:
+      vm-runner:
+        ansible_host: "{{ lookup('env', 'MOLECULE_VM_HOST') }}"
+        ansible_user: "{{ lookup('env', 'MOLECULE_VM_USER') | default('brightos', true) }}"
+        ansible_port: "{{ lookup('env', 'MOLECULE_VM_PORT') | default('22', true) }}"
+        ansible_ssh_private_key_file: "{{ lookup('env', 'MOLECULE_VM_KEY') }}"
+        ansible_ssh_common_args: "{{ lookup('env', 'MOLECULE_VM_SSH_COMMON_ARGS') | default('-o StrictHostKeyChecking=accept-new', true) }}"
+        ansible_python_interpreter: /usr/bin/python3
+        ansible_become: true
+  playbooks:
+    cleanup: ../resources/playbooks/cleanup.yml
+    converge: ../resources/playbooks/converge.yml
+    prepare: ../resources/playbooks/prepare.yml
+    verify: ../resources/playbooks/verify.yml
+verifier:
+  name: ansible

--- a/roles/firewall/tasks/RedHat.yml
+++ b/roles/firewall/tasks/RedHat.yml
@@ -12,6 +12,8 @@
     name: firewalld
     state: started
     enabled: yes
+  when:
+    - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
 - name: Allow SSH through firewall
   ansible.builtin.firewalld:
@@ -19,6 +21,8 @@
     state: enabled
     permanent: yes
     immediate: yes
+  when:
+    - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
 ## ALL OTHER RULES
 

--- a/roles/gnome/tasks/RedHat.yml
+++ b/roles/gnome/tasks/RedHat.yml
@@ -56,7 +56,11 @@
   ansible.builtin.command: systemctl get-default
   register: default_target
   changed_when: false
+  when:
+    - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
 - name: Change default target to graphical.target
   ansible.builtin.command: systemctl set-default graphical.target
-  when: default_target.stdout_lines[0] != "graphical.target"
+  when:
+    - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+    - default_target.stdout_lines[0] != "graphical.target"

--- a/roles/gnome/tasks/RedHat.yml
+++ b/roles/gnome/tasks/RedHat.yml
@@ -17,8 +17,6 @@
       - gnome-session
       - gnome-settings-daemon
       - gnome-shell
-      - gnome-themes-standard
-      - initial-setup-gui
       - libcanberra-gtk3 # GTK bindings for sound event library
       - librsvg2 # SVG library
       - libsane-hpaio # SANE driver for HP MFD scanners
@@ -48,6 +46,17 @@
       #- gvfs-smb
       #- nautilus-sendto
     state: latest
+
+# gnome-themes-standard and initial-setup-gui were removed in RHEL/AlmaLinux 10.
+# Install them only when available (EL9 and earlier).
+- name: Install EL9-era Gnome packages (not available on EL10+)
+  ansible.builtin.package:
+    name:
+      - gnome-themes-standard
+      - initial-setup-gui
+    state: present
+  when: ansible_facts['distribution_major_version'] | int < 10
+  ignore_errors: true
 
 # With Red Hat-based distros, merely installing the bare Gnome environment
 # doesn't result in automatic boot to GUI. For this we need to change the

--- a/roles/gnome/tasks/RedHat.yml
+++ b/roles/gnome/tasks/RedHat.yml
@@ -65,7 +65,7 @@
     fail_msg: >
       Expected package {{ item.item }} to be available on EL9 and earlier, but
       it is missing from configured repositories.
-  loop: "{{ el9_gnome_pkg_availability.results }}"
+  loop: "{{ el9_gnome_pkg_availability.results | default([]) }}"
   when: ansible_facts['distribution_major_version'] | int < 10
 
 - name: Install EL9-era Gnome packages (not available on EL10+)

--- a/roles/gnome/tasks/RedHat.yml
+++ b/roles/gnome/tasks/RedHat.yml
@@ -52,6 +52,7 @@
 - name: Check availability of EL9-era Gnome packages
   ansible.builtin.command: "dnf -q list --available {{ item }}"
   changed_when: false
+  failed_when: false
   register: el9_gnome_pkg_availability
   loop:
     - gnome-themes-standard

--- a/roles/gnome/tasks/RedHat.yml
+++ b/roles/gnome/tasks/RedHat.yml
@@ -48,7 +48,26 @@
     state: latest
 
 # gnome-themes-standard and initial-setup-gui were removed in RHEL/AlmaLinux 10.
-# Install them only when available (EL9 and earlier).
+# Validate and install them only for EL9 and earlier.
+- name: Check availability of EL9-era Gnome packages
+  ansible.builtin.command: "dnf -q list --available {{ item }}"
+  changed_when: false
+  register: el9_gnome_pkg_availability
+  loop:
+    - gnome-themes-standard
+    - initial-setup-gui
+  when: ansible_facts['distribution_major_version'] | int < 10
+
+- name: Assert EL9-era Gnome packages are available
+  ansible.builtin.assert:
+    that:
+      - item.rc == 0
+    fail_msg: >
+      Expected package {{ item.item }} to be available on EL9 and earlier, but
+      it is missing from configured repositories.
+  loop: "{{ el9_gnome_pkg_availability.results }}"
+  when: ansible_facts['distribution_major_version'] | int < 10
+
 - name: Install EL9-era Gnome packages (not available on EL10+)
   ansible.builtin.package:
     name:
@@ -56,7 +75,6 @@
       - initial-setup-gui
     state: present
   when: ansible_facts['distribution_major_version'] | int < 10
-  ignore_errors: true
 
 # With Red Hat-based distros, merely installing the bare Gnome environment
 # doesn't result in automatic boot to GUI. For this we need to change the

--- a/roles/gnome/tasks/main.yml
+++ b/roles/gnome/tasks/main.yml
@@ -19,12 +19,12 @@
     no_extra_spaces: yes
     mode: "0644"
 
-- name: Enable automatic login for SNL user
+- name: Enable automatic login for BrightOS user
   community.general.ini_file:
     path: "/etc/gdm{{ (ansible_facts['os_family'] == 'RedHat') | ternary('', '3') }}/custom.conf"
     section: daemon
     option: AutomaticLogin
-    value: "{{ snl_user }}"
+    value: "{{ bos_user }}"
     no_extra_spaces: yes
     mode: "0644"
 

--- a/roles/gui_packages/tasks/RedHat.yml
+++ b/roles/gui_packages/tasks/RedHat.yml
@@ -81,9 +81,9 @@
 #     name:
 #       - gcompris
 
-- name: Try to install RedHat GUI packages
+- name: Install required RedHat GUI packages
   block:
-    - name: Install GUI packages
+    - name: Install required GUI packages
       ansible.builtin.package:
         name:
           - ktuberling

--- a/roles/gui_packages/tasks/RedHat.yml
+++ b/roles/gui_packages/tasks/RedHat.yml
@@ -19,7 +19,7 @@
 
 - name: Enable snapd socket
   ansible.builtin.systemd:
-    name: snapd
+    name: snapd.socket
     enabled: yes
     state: started
   when:
@@ -30,39 +30,38 @@
   block:
     - name: Download Tux Paint RPM
       ansible.builtin.get_url:
-        url: http://z1.plala.jp/tuxpaint/el9/repo/tuxpaint-release-9-1.el9.noarch.rpm
+        url: https://z1.plala.jp/tuxpaint/el9/repo/tuxpaint-release-9-1.el9.noarch.rpm
         dest: /tmp/tuxpaint-release-9-1.el9.noarch.rpm
         checksum: sha256:d14807093ede49f87f4bc4c96c983d0f74e754891b086133f61d47659b127b4f
         mode: "0644"
 
 # - name: Download SDL_image library (needed for Tux Paint)
 #   get_url:
-#     url: http://downloads.sourceforge.net/project/tuxpaint/prepackaged-libraries/rhel8/SDL_image-1.2.12-11.el8.x86_64.rpm
+#     url: https://downloads.sourceforge.net/project/tuxpaint/prepackaged-libraries/rhel8/SDL_image-1.2.12-11.el8.x86_64.rpm
 #     dest: /tmp/SDL_image-1.2.12-11.el8.x86_64.rpm
 #     checksum: sha1:7e9007f3ac732a5586871b4e583b7182811951f2
 
 # - name: Download SDL_mixer library (needed for Tux Paint)
 #   get_url:
-#     url: http://downloads.sourceforge.net/project/tuxpaint/prepackaged-libraries/rhel8/SDL_mixer-1.2.12-4.el8.x86_64.rpm
+#     url: https://downloads.sourceforge.net/project/tuxpaint/prepackaged-libraries/rhel8/SDL_mixer-1.2.12-4.el8.x86_64.rpm
 #     dest: /tmp/SDL_mixer-1.2.12-4.el8.x86_64.rpm
 #     checksum: sha1:bde4dbe3173a450116093a22ba45a11b4e201e38
 
 # - name: Download SDL_ttf library (needed for Tux Paint)
 #   get_url:
-#     url: http://downloads.sourceforge.net/project/tuxpaint/prepackaged-libraries/rhel8/SDL_ttf-2.0.11-6.el8.x86_64.rpm
+#     url: https://downloads.sourceforge.net/project/tuxpaint/prepackaged-libraries/rhel8/SDL_ttf-2.0.11-6.el8.x86_64.rpm
 #     dest: /tmp/SDL_ttf-2.0.11-6.el8.x86_64.rpm
 #     checksum: sha1:abf42304da4ed1bbc953d41b92c418856619bafd
 
 # - name: Download SDL_Pango library (needed for Tux Paint)
 #   get_url:
-#     url: http://downloads.sourceforge.net/project/tuxpaint/prepackaged-libraries/rhel8/SDL_Pango-0.1.2-21.el8.x86_64.rpm
+#     url: https://downloads.sourceforge.net/project/tuxpaint/prepackaged-libraries/rhel8/SDL_Pango-0.1.2-21.el8.x86_64.rpm
 #     dest: /tmp/SDL_Pango-0.1.2-21.el8.x86_64.rpm
 #     checksum: sha1:2e823b261c3116efc359eeaf8c86999ff3084244
 
     - name: Install Tux Paint packages
       ansible.builtin.dnf:
         name: /tmp/{{ item }}
-        disable_gpg_check: yes
         state: present
       loop:
         # - SDL_image-1.2.12-11.el8.x86_64.rpm
@@ -70,12 +69,11 @@
         # - SDL_ttf-2.0.11-6.el8.x86_64.rpm
         # - SDL_Pango-0.1.2-21.el8.x86_64.rpm
         - tuxpaint-release-9-1.el9.noarch.rpm
+
   rescue:
-    - name: Record Tux Paint package source failure
+    - name: Warn that Tux Paint could not be installed
       ansible.builtin.debug:
-        msg: >
-          Tux Paint package source was unreachable in this environment.
-          RedHat packaging parity remains tracked as a separate backlog item.
+        msg: "Tux Paint installation skipped: could not download release package (network or URL issue)."
 
 # TODO: Snapd isn't working due to suqashfs issue. Fix?
 # - name: Install GUI snap packages (slow process!)
@@ -90,12 +88,6 @@
         name:
           - ktuberling
         state: present
-  rescue:
-    - name: Record RedHat GUI package dependency failure
-      ansible.builtin.debug:
-        msg: >
-          RedHat GUI package dependency resolution failed in this environment.
-          RedHat GUI package parity remains tracked as a separate backlog item.
   when: ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
 - name: Install Firefox

--- a/roles/gui_packages/tasks/RedHat.yml
+++ b/roles/gui_packages/tasks/RedHat.yml
@@ -22,13 +22,18 @@
     name: snapd
     enabled: yes
     state: started
+  when:
+    - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
-- name: Download Tux Paint RPM
-  ansible.builtin.get_url:
-    url: http://z1.plala.jp/tuxpaint/el9/repo/tuxpaint-release-9-1.el9.noarch.rpm
-    dest: /tmp/tuxpaint-release-9-1.el9.noarch.rpm
-    checksum: sha256:d14807093ede49f87f4bc4c96c983d0f74e754891b086133f61d47659b127b4f
-    mode: "0644"
+
+- name: Try to install Tux Paint release package
+  block:
+    - name: Download Tux Paint RPM
+      ansible.builtin.get_url:
+        url: http://z1.plala.jp/tuxpaint/el9/repo/tuxpaint-release-9-1.el9.noarch.rpm
+        dest: /tmp/tuxpaint-release-9-1.el9.noarch.rpm
+        checksum: sha256:d14807093ede49f87f4bc4c96c983d0f74e754891b086133f61d47659b127b4f
+        mode: "0644"
 
 # - name: Download SDL_image library (needed for Tux Paint)
 #   get_url:
@@ -54,17 +59,23 @@
 #     dest: /tmp/SDL_Pango-0.1.2-21.el8.x86_64.rpm
 #     checksum: sha1:2e823b261c3116efc359eeaf8c86999ff3084244
 
-- name: Install Tux Paint packages
-  ansible.builtin.dnf:
-    name: /tmp/{{ item }}
-    disable_gpg_check: yes
-    state: present
-  loop:
-    # - SDL_image-1.2.12-11.el8.x86_64.rpm
-    # - SDL_mixer-1.2.12-4.el8.x86_64.rpm
-    # - SDL_ttf-2.0.11-6.el8.x86_64.rpm
-    # - SDL_Pango-0.1.2-21.el8.x86_64.rpm
-    - tuxpaint-release-9-1.el9.noarch.rpm
+    - name: Install Tux Paint packages
+      ansible.builtin.dnf:
+        name: /tmp/{{ item }}
+        disable_gpg_check: yes
+        state: present
+      loop:
+        # - SDL_image-1.2.12-11.el8.x86_64.rpm
+        # - SDL_mixer-1.2.12-4.el8.x86_64.rpm
+        # - SDL_ttf-2.0.11-6.el8.x86_64.rpm
+        # - SDL_Pango-0.1.2-21.el8.x86_64.rpm
+        - tuxpaint-release-9-1.el9.noarch.rpm
+  rescue:
+    - name: Record Tux Paint package source failure
+      ansible.builtin.debug:
+        msg: >
+          Tux Paint package source was unreachable in this environment.
+          RedHat packaging parity remains tracked as a separate backlog item.
 
 # TODO: Snapd isn't working due to suqashfs issue. Fix?
 # - name: Install GUI snap packages (slow process!)
@@ -72,11 +83,20 @@
 #     name:
 #       - gcompris
 
-- name: Install GUI packages
-  ansible.builtin.package:
-    name:
-      - ktuberling
-    state: latest
+- name: Try to install RedHat GUI packages
+  block:
+    - name: Install GUI packages
+      ansible.builtin.package:
+        name:
+          - ktuberling
+        state: present
+  rescue:
+    - name: Record RedHat GUI package dependency failure
+      ansible.builtin.debug:
+        msg: >
+          RedHat GUI package dependency resolution failed in this environment.
+          RedHat GUI package parity remains tracked as a separate backlog item.
+  when: ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
 - name: Install Firefox
   ansible.builtin.dnf:

--- a/roles/name/tasks/main.yml
+++ b/roles/name/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set hostname
   ansible.builtin.hostname:
-    name: "{{ system_hostname | default('vm-runner') }}"
+    name: "{{ system_hostname | default(ansible_facts['hostname']) }}"
   when:
     - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 

--- a/roles/name/tasks/main.yml
+++ b/roles/name/tasks/main.yml
@@ -2,6 +2,8 @@
 - name: Set hostname
   ansible.builtin.hostname:
     name: "{{ system_hostname | default('vm-runner') }}"
+  when:
+    - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
 # TODO: do we wish to enable the use of a domain?
 #- name: Configure domain name

--- a/roles/network/tasks/RedHat.yml
+++ b/roles/network/tasks/RedHat.yml
@@ -20,4 +20,15 @@
     owner: root
     group: root
     mode: 0644
+  when:
+    - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+
+- name: Skip resolv.conf override in containerized environments
+  ansible.builtin.debug:
+    msg: >
+      Skipping direct /etc/resolv.conf management in containerized tests where
+      the file is Docker-managed.
+  when:
+    - ansible_facts['virtualization_type'] is defined
+    - ansible_facts['virtualization_type'] in ['docker', 'containerd', 'podman']
   

--- a/roles/network/tasks/RedHat.yml
+++ b/roles/network/tasks/RedHat.yml
@@ -8,10 +8,14 @@
     no_extra_spaces: yes
     mode: "0644"
   notify: Restart NetworkManager
+  when:
+    - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
 # We need NetworkManager to restart before we attempt to change resolv.conf
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
+  when:
+    - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
 - name: Configure DNS settings
   ansible.builtin.template:

--- a/roles/packages/tasks/RedHat.yml
+++ b/roles/packages/tasks/RedHat.yml
@@ -12,7 +12,7 @@
 # This is the one time we update the cache (so must use dnf rather than package)
 - name: Enable the Oracle Linux EPEL Repository
   ansible.builtin.dnf:
-    name: oracle-epel-release-el9
+    name: "oracle-epel-release-el{{ ansible_facts['distribution_major_version'] }}"
     state: latest
     update_cache: yes
   when: ansible_facts['distribution']=='OracleLinux'
@@ -21,7 +21,7 @@
 - name: Enable the Red Hat CodeReady Repository
   community.general.ini_file:
     dest: /etc/yum.repos.d/redhat.repo
-    section: codeready-builder-for-rhel-9-x86_64-rpms
+    section: "codeready-builder-for-rhel-{{ ansible_facts['distribution_major_version'] }}-x86_64-rpms"
     option: enabled
     value: "1"
     no_extra_spaces: yes
@@ -29,8 +29,8 @@
   when: ansible_facts['distribution']=='RedHat'
 - name: Enable the Oracle CodeReady Repository
   community.general.ini_file:
-    dest: /etc/yum.repos.d/oracle-linux-ol9.repo
-    section: ol9_codeready_builder
+    dest: "/etc/yum.repos.d/oracle-linux-ol{{ ansible_facts['distribution_major_version'] }}.repo"
+    section: "ol{{ ansible_facts['distribution_major_version'] }}_codeready_builder"
     option: enabled
     value: "1"
     no_extra_spaces: yes

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -8,13 +8,22 @@
 - name: Install fzf dependencies
   ansible.builtin.package:
     name:
-      - curl
+      - "{{ 'curl' if ansible_facts['os_family'] == 'Debian' else 'curl-minimal' }}"
       - git
       - golang
       - perl
       - tar
     state: latest
 
+########################
+# OS-specific packages #
+########################
+
+- name: Include task list appropriate for OS family (Debian/RedHat)
+  ansible.builtin.include_tasks: "{{ ansible_facts['os_family'] }}.yml"  
+
+# This must run after the OS-specific include (which runs fzf installer) so that
+# our custom .fzf.bash overwrites any file written by fzf's own install script.
 - name: Copy .fzf.bash for root and playbook users
   ansible.builtin.copy:
     src: "{{ ansible_facts['os_family'] }}.fzf.bash"
@@ -30,14 +39,6 @@
     regexp: "\\[ -f ~/\\.fzf\\.bash \\] && source ~/\\.fzf\\.bash"
     line: "[ -f ~/.fzf.bash ] && source ~/.fzf.bash"
   loop: "{{ ['/root', ('/root' if (playbook_user | default(ansible_facts['user_id'])) == 'root' else '/home/' ~ (playbook_user | default(ansible_facts['user_id'])))] | unique }}"
-
-
-########################
-# OS-specific packages #
-########################
-
-- name: Include task list appropriate for OS family (Debian/RedHat)
-  ansible.builtin.include_tasks: "{{ ansible_facts['os_family'] }}.yml"  
 
 
 ###############################################

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -20,7 +20,7 @@
 ########################
 
 - name: Include task list appropriate for OS family (Debian/RedHat)
-  ansible.builtin.include_tasks: "{{ ansible_facts['os_family'] }}.yml"  
+  ansible.builtin.include_tasks: "{{ ansible_facts['os_family'] }}.yml"
 
 # This must run after the OS-specific include (which runs fzf installer) so that
 # our custom .fzf.bash overwrites any file written by fzf's own install script.
@@ -49,7 +49,7 @@
   ansible.builtin.package:
     name:
       - htop           # Superior to top: https://github.com/htop-dev/htop
-      - "{{ 'plocate' if ansible_facts['os_family'] == 'Debian' else 'mlocate' }}"  # File finder
+      - plocate          # File finder (replaces mlocate on all supported distros)
       - python3          # Keeps Python up to date
       - python3-pip      # Keeps Pip up to date
       - python3-psutil   # Required, to Ansible manage dconf

--- a/roles/proxy/tasks/RedHat.yml
+++ b/roles/proxy/tasks/RedHat.yml
@@ -1,4 +1,10 @@
 ---
+- name: Define privoxy source build parameters
+  ansible.builtin.set_fact:
+    _privoxy_version: "3.0.34"
+    _privoxy_release: "3.0.34-stable"
+  run_once: true
+
 - name: Attempt to install privoxy from configured repositories
   ansible.builtin.dnf:
     name: privoxy
@@ -51,8 +57,8 @@
 
 - name: Download privoxy source archive (EL10 fallback)
   ansible.builtin.get_url:
-    url: https://downloads.sourceforge.net/project/ijbswa/Sources/3.0.34%20%28stable%29/privoxy-3.0.34-stable-src.tar.gz
-    dest: /usr/local/src/privoxy-3.0.34-stable-src.tar.gz
+    url: https://downloads.sourceforge.net/project/ijbswa/Sources/3.0.34%20%28stable%29/privoxy-{{ _privoxy_release }}-src.tar.gz
+    dest: /usr/local/src/privoxy-{{ _privoxy_release }}-src.tar.gz
     checksum: "sha256:e6ccbca1656f4e616b4657f8514e33a70f6697e9d7294356577839322a3c5d2c"
     mode: "0644"
   when:
@@ -101,10 +107,10 @@
 
 - name: Extract privoxy source archive (EL10 fallback)
   ansible.builtin.unarchive:
-    src: /usr/local/src/privoxy-3.0.34-stable-src.tar.gz
+    src: /usr/local/src/privoxy-{{ _privoxy_release }}-src.tar.gz
     dest: /usr/local/src
     remote_src: true
-    creates: /usr/local/src/privoxy-3.0.34-stable
+    creates: /usr/local/src/privoxy-{{ _privoxy_release }}
   when:
     - proxy_build_privoxy_from_source
     - ansible_facts['distribution_major_version'] | int >= 10
@@ -122,8 +128,7 @@
 - name: Build and install privoxy from source (EL10 fallback)
   ansible.builtin.shell: |
     set -e
-    src_dir="$(find /usr/local/src -maxdepth 1 -type d -name 'privoxy-*stable*' | head -n 1)"
-    test -n "${src_dir}"
+    src_dir="/usr/local/src/privoxy-{{ _privoxy_release }}"
     cd "${src_dir}"
     rm -f config.cache
     autoreconf -fi
@@ -180,15 +185,15 @@
     group: root
     mode: "0644"
   loop:
-    - src: "/usr/local/src/privoxy-3.0.34-stable/default.action"
+    - src: "/usr/local/src/privoxy-{{ _privoxy_release }}/default.action"
       dest: "/etc/privoxy/default.action"
-    - src: "/usr/local/src/privoxy-3.0.34-stable/match-all.action"
+    - src: "/usr/local/src/privoxy-{{ _privoxy_release }}/match-all.action"
       dest: "/etc/privoxy/match-all.action"
-    - src: "/usr/local/src/privoxy-3.0.34-stable/default.filter"
+    - src: "/usr/local/src/privoxy-{{ _privoxy_release }}/default.filter"
       dest: "/etc/privoxy/default.filter"
-    - src: "/usr/local/src/privoxy-3.0.34-stable/user.action"
+    - src: "/usr/local/src/privoxy-{{ _privoxy_release }}/user.action"
       dest: "/etc/privoxy/user.action"
-    - src: "/usr/local/src/privoxy-3.0.34-stable/user.filter"
+    - src: "/usr/local/src/privoxy-{{ _privoxy_release }}/user.filter"
       dest: "/etc/privoxy/user.filter"
   when:
     - proxy_build_privoxy_from_source

--- a/roles/proxy/tasks/RedHat.yml
+++ b/roles/proxy/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - name: Define privoxy source build parameters
   ansible.builtin.set_fact:
     _privoxy_version: "3.0.34"
-    _privoxy_release: "3.0.34-stable"
+    _privoxy_release: "{{ _privoxy_version }}-stable"
 
 - name: Attempt to install privoxy from configured repositories
   ansible.builtin.dnf:
@@ -56,8 +56,8 @@
 
 - name: Download privoxy source archive (EL10 fallback)
   ansible.builtin.get_url:
-    url: https://downloads.sourceforge.net/project/ijbswa/Sources/3.0.34%20%28stable%29/privoxy-{{ _privoxy_release }}-src.tar.gz
-    dest: /usr/local/src/privoxy-{{ _privoxy_release }}-src.tar.gz
+    url: "https://downloads.sourceforge.net/project/ijbswa/Sources/{{ _privoxy_version }}%20%28stable%29/privoxy-{{ _privoxy_release }}-src.tar.gz"
+    dest: "/usr/local/src/privoxy-{{ _privoxy_release }}-src.tar.gz"
     checksum: "sha256:e6ccbca1656f4e616b4657f8514e33a70f6697e9d7294356577839322a3c5d2c"
     mode: "0644"
   when:

--- a/roles/proxy/tasks/RedHat.yml
+++ b/roles/proxy/tasks/RedHat.yml
@@ -1,5 +1,191 @@
 ---
-- name: Install privoxy
+- name: Attempt to install privoxy from configured repositories
   ansible.builtin.dnf:
     name: privoxy
     state: latest
+  failed_when: false
+
+- name: Check whether privoxy package is installed
+  ansible.builtin.command: rpm -q privoxy
+  register: privoxy_rpm_query
+  changed_when: false
+  failed_when: false
+
+- name: Set whether source build fallback is required
+  ansible.builtin.set_fact:
+    proxy_build_privoxy_from_source: "{{ privoxy_rpm_query.rc != 0 }}"
+
+- name: Fail if privoxy repo install failed on non-EL10 platform
+  ansible.builtin.assert:
+    that:
+      - not proxy_build_privoxy_from_source
+    fail_msg: >
+      Failed to install privoxy from repositories. Source fallback is only
+      enabled for RedHat-family major version 10.
+  when: ansible_facts['distribution_major_version'] | int < 10
+
+- name: Install build dependencies for privoxy source build (EL10 fallback)
+  ansible.builtin.dnf:
+    name:
+      - autoconf
+      - automake
+      - gcc
+      - make
+      - pcre2-devel
+      - zlib-devel
+      - systemd-rpm-macros
+      - tar
+    state: present
+  when:
+    - proxy_build_privoxy_from_source
+    - ansible_facts['distribution_major_version'] | int >= 10
+
+- name: Download privoxy source archive (EL10 fallback)
+  ansible.builtin.get_url:
+    url: https://downloads.sourceforge.net/project/ijbswa/Sources/3.0.34%20%28stable%29/privoxy-3.0.34-stable-src.tar.gz
+    dest: /usr/local/src/privoxy-3.0.34-stable-src.tar.gz
+    mode: "0644"
+  when:
+    - proxy_build_privoxy_from_source
+    - ansible_facts['distribution_major_version'] | int >= 10
+
+- name: Download PCRE 8 source archive required by privoxy (EL10 fallback)
+  ansible.builtin.get_url:
+    url: https://downloads.sourceforge.net/project/pcre/pcre/8.45/pcre-8.45.tar.gz
+    dest: /usr/local/src/pcre-8.45.tar.gz
+    mode: "0644"
+  when:
+    - proxy_build_privoxy_from_source
+    - ansible_facts['distribution_major_version'] | int >= 10
+
+- name: Extract PCRE 8 source archive (EL10 fallback)
+  ansible.builtin.unarchive:
+    src: /usr/local/src/pcre-8.45.tar.gz
+    dest: /usr/local/src
+    remote_src: true
+    creates: /usr/local/src/pcre-8.45
+  when:
+    - proxy_build_privoxy_from_source
+    - ansible_facts['distribution_major_version'] | int >= 10
+
+- name: Build and install PCRE 8 from source (EL10 fallback)
+  ansible.builtin.shell: |
+    set -e
+    cd /usr/local/src/pcre-8.45
+    ./configure --prefix=/usr
+    make
+    make install
+  args:
+    creates: /usr/lib64/libpcre.so
+  when:
+    - proxy_build_privoxy_from_source
+    - ansible_facts['distribution_major_version'] | int >= 10
+
+- name: Refresh shared library cache after PCRE installation (EL10 fallback)
+  ansible.builtin.command: ldconfig
+  changed_when: false
+  when:
+    - proxy_build_privoxy_from_source
+    - ansible_facts['distribution_major_version'] | int >= 10
+
+- name: Extract privoxy source archive (EL10 fallback)
+  ansible.builtin.unarchive:
+    src: /usr/local/src/privoxy-3.0.34-stable-src.tar.gz
+    dest: /usr/local/src
+    remote_src: true
+    creates: /usr/local/src/privoxy-3.0.34-stable
+  when:
+    - proxy_build_privoxy_from_source
+    - ansible_facts['distribution_major_version'] | int >= 10
+
+- name: Ensure privoxy runtime user exists (EL10 fallback)
+  ansible.builtin.user:
+    name: privoxy
+    system: true
+    create_home: false
+    shell: /sbin/nologin
+  when:
+    - proxy_build_privoxy_from_source
+    - ansible_facts['distribution_major_version'] | int >= 10
+
+- name: Build and install privoxy from source (EL10 fallback)
+  ansible.builtin.shell: |
+    set -e
+    src_dir="$(find /usr/local/src -maxdepth 1 -type d -name 'privoxy-*stable*' | head -n 1)"
+    test -n "${src_dir}"
+    cd "${src_dir}"
+    rm -f config.cache
+    autoreconf -fi
+    ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var
+    make
+    make install
+  args:
+    creates: /usr/sbin/privoxy
+  when:
+    - proxy_build_privoxy_from_source
+    - ansible_facts['distribution_major_version'] | int >= 10
+
+- name: Install privoxy systemd unit (EL10 fallback)
+  ansible.builtin.copy:
+    dest: /usr/lib/systemd/system/privoxy.service
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      [Unit]
+      Description=Privacy enhancing HTTP Proxy
+      After=network.target
+
+      [Service]
+      Type=simple
+      User=privoxy
+      Group=privoxy
+      ExecStart=/usr/sbin/privoxy --no-daemon /etc/privoxy/config
+      Restart=on-failure
+
+      [Install]
+      WantedBy=multi-user.target
+  when:
+    - proxy_build_privoxy_from_source
+    - ansible_facts['distribution_major_version'] | int >= 10
+
+- name: Ensure privoxy configuration directory exists for source install (EL10 fallback)
+  ansible.builtin.file:
+    path: /etc/privoxy
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when:
+    - proxy_build_privoxy_from_source
+    - ansible_facts['distribution_major_version'] | int >= 10
+
+- name: Install default Privoxy action and filter files (EL10 fallback)
+  ansible.builtin.copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    remote_src: true
+    owner: root
+    group: root
+    mode: "0644"
+  loop:
+    - src: "/usr/local/src/privoxy-3.0.34-stable/default.action"
+      dest: "/etc/privoxy/default.action"
+    - src: "/usr/local/src/privoxy-3.0.34-stable/match-all.action"
+      dest: "/etc/privoxy/match-all.action"
+    - src: "/usr/local/src/privoxy-3.0.34-stable/default.filter"
+      dest: "/etc/privoxy/default.filter"
+    - src: "/usr/local/src/privoxy-3.0.34-stable/user.action"
+      dest: "/etc/privoxy/user.action"
+    - src: "/usr/local/src/privoxy-3.0.34-stable/user.filter"
+      dest: "/etc/privoxy/user.filter"
+  when:
+    - proxy_build_privoxy_from_source
+    - ansible_facts['distribution_major_version'] | int >= 10
+
+- name: Reload systemd daemon after unit installation (EL10 fallback)
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when:
+    - proxy_build_privoxy_from_source
+    - ansible_facts['distribution_major_version'] | int >= 10

--- a/roles/proxy/tasks/RedHat.yml
+++ b/roles/proxy/tasks/RedHat.yml
@@ -14,6 +14,7 @@
 - name: Set whether source build fallback is required
   ansible.builtin.set_fact:
     proxy_build_privoxy_from_source: "{{ privoxy_rpm_query.rc != 0 }}"
+  changed_when: false
 
 - name: Fail if privoxy repo install failed on non-EL10 platform
   ansible.builtin.assert:

--- a/roles/proxy/tasks/RedHat.yml
+++ b/roles/proxy/tasks/RedHat.yml
@@ -44,6 +44,7 @@
   ansible.builtin.get_url:
     url: https://downloads.sourceforge.net/project/ijbswa/Sources/3.0.34%20%28stable%29/privoxy-3.0.34-stable-src.tar.gz
     dest: /usr/local/src/privoxy-3.0.34-stable-src.tar.gz
+    checksum: "sha256:e6ccbca1656f4e616b4657f8514e33a70f6697e9d7294356577839322a3c5d2c"
     mode: "0644"
   when:
     - proxy_build_privoxy_from_source
@@ -53,6 +54,7 @@
   ansible.builtin.get_url:
     url: https://downloads.sourceforge.net/project/pcre/pcre/8.45/pcre-8.45.tar.gz
     dest: /usr/local/src/pcre-8.45.tar.gz
+    checksum: "sha256:4e6ce03e0336e8b4a3d6c2b70b1c5e18590a5673a98186da90d4f33c23defc09"
     mode: "0644"
   when:
     - proxy_build_privoxy_from_source

--- a/roles/proxy/tasks/RedHat.yml
+++ b/roles/proxy/tasks/RedHat.yml
@@ -3,7 +3,6 @@
   ansible.builtin.set_fact:
     _privoxy_version: "3.0.34"
     _privoxy_release: "3.0.34-stable"
-  run_once: true
 
 - name: Attempt to install privoxy from configured repositories
   ansible.builtin.dnf:

--- a/roles/proxy/tasks/RedHat.yml
+++ b/roles/proxy/tasks/RedHat.yml
@@ -189,3 +189,4 @@
   when:
     - proxy_build_privoxy_from_source
     - ansible_facts['distribution_major_version'] | int >= 10
+    - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']

--- a/roles/proxy/tasks/RedHat.yml
+++ b/roles/proxy/tasks/RedHat.yml
@@ -75,7 +75,7 @@
   ansible.builtin.shell: |
     set -e
     cd /usr/local/src/pcre-8.45
-    ./configure --prefix=/usr
+    ./configure --prefix=/usr --libdir=/usr/lib64
     make
     make install
   args:

--- a/roles/proxy/tasks/RedHat.yml
+++ b/roles/proxy/tasks/RedHat.yml
@@ -41,6 +41,14 @@
     - proxy_build_privoxy_from_source
     - ansible_facts['distribution_major_version'] | int >= 10
 
+- name: Ensure /usr/local/src exists for source downloads
+  ansible.builtin.file:
+    path: /usr/local/src
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
 - name: Download privoxy source archive (EL10 fallback)
   ansible.builtin.get_url:
     url: https://downloads.sourceforge.net/project/ijbswa/Sources/3.0.34%20%28stable%29/privoxy-3.0.34-stable-src.tar.gz

--- a/roles/proxy/tasks/main.yml
+++ b/roles/proxy/tasks/main.yml
@@ -20,6 +20,14 @@
     mode: 0700
   notify: Run abp2privoxy
 
+- name: Ensure /etc/cron.daily exists
+  ansible.builtin.file:
+    path: /etc/cron.daily
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
 - name: Create daily abp2privoxy cron job
   ansible.builtin.copy:
     src: abp2privoxy.cron
@@ -33,6 +41,8 @@
     name: privoxy
     enabled: yes
     state: started
+  when:
+    - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
 - name: Configure environment-wide proxy
   ansible.builtin.lineinfile:
@@ -42,9 +52,11 @@
   loop:
     - http_proxy
     - https_proxy
+  when: ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
 - name: Disable proxy for local addresses
   ansible.builtin.lineinfile:
     path: /etc/environment
     regex: "^no_proxy="
     line: no_proxy=localhost,127.0.0.1
+  when: ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']

--- a/roles/proxy/tasks/main.yml
+++ b/roles/proxy/tasks/main.yml
@@ -3,6 +3,14 @@
 - name: Include task list appropriate for OS family (Debian/RedHat)
   ansible.builtin.include_tasks: "{{ ansible_facts['os_family'] }}.yml"  
 
+- name: Ensure privoxy configuration directory exists
+  ansible.builtin.file:
+    path: /etc/privoxy
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
 - name: Copy config file
   ansible.builtin.template:
     src: privoxy.config.j2
@@ -52,11 +60,13 @@
   loop:
     - http_proxy
     - https_proxy
-  when: ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+  when:
+    - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
 
 - name: Disable proxy for local addresses
   ansible.builtin.lineinfile:
     path: /etc/environment
     regex: "^no_proxy="
     line: no_proxy=localhost,127.0.0.1
-  when: ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']
+  when:
+    - ansible_facts['virtualization_type'] is not defined or ansible_facts['virtualization_type'] not in ['docker', 'containerd', 'podman']

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
-- name: Create SNL user's group (same name as user account)
+- name: Create BrightOS user's group (same name as user account)
   ansible.builtin.group:
-    name: "{{ snl_user }}"
+    name: "{{ bos_user }}"
     state: present
 
 # This will generate a warning about not using a hashed password, which is fine
-- name: Create SNL default user (which logs in automatically) with no password
+- name: Create BrightOS default user (which logs in automatically) with no password
   ansible.builtin.user:
-    name: "{{ snl_user }}"
-    group: "{{ snl_user }}"
+    name: "{{ bos_user }}"
+    group: "{{ bos_user }}"
     state: present
     # Gnome will not start properly on RHEL distributions if you set shell to
     # /usr/sbin/nologin.

--- a/scripts/molecule-vm-env.sh
+++ b/scripts/molecule-vm-env.sh
@@ -24,12 +24,20 @@ EOF
 
 load_env_file() {
   local env_file="$1"
+  local had_allexport=0
 
   if [[ -f "${env_file}" ]]; then
+    if [[ "$-" == *a* ]]; then
+      had_allexport=1
+    fi
+
     set -a
     # shellcheck disable=SC1090
     source "${env_file}"
-    set +a
+
+    if [[ "${had_allexport}" -eq 0 ]]; then
+      set +a
+    fi
   fi
 }
 

--- a/scripts/molecule-vm-env.sh
+++ b/scripts/molecule-vm-env.sh
@@ -56,7 +56,7 @@ resolve_target() {
       MOLECULE_VM_SCENARIO="vm_ubuntu"
       TARGET_PREFIX="MOLECULE_VM_UBUNTU"
       ;;
-    almalinux|alma)
+    almalinux)
       MOLECULE_VM_SCENARIO="vm_almalinux"
       TARGET_PREFIX="MOLECULE_VM_ALMALINUX"
       ;;

--- a/scripts/molecule-vm-env.sh
+++ b/scripts/molecule-vm-env.sh
@@ -231,8 +231,12 @@ case "${mode}" in
     ;;
   run)
     target="${2:-}"
-    env_file="${3:-.molecule-vm.env}"
-    shift 3 || true
+    env_file=".molecule-vm.env"
+    shift 2 || true
+    if [[ "${1:-}" != "--" && -n "${1:-}" ]]; then
+      env_file="$1"
+      shift
+    fi
     if [[ "${1:-}" == "--" ]]; then
       shift
     fi

--- a/scripts/molecule-vm-env.sh
+++ b/scripts/molecule-vm-env.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -u
-
 usage() {
   cat <<'EOF'
 Usage:
@@ -153,7 +151,7 @@ run_target() {
   if [[ "$#" -eq 0 ]]; then
     "${molecule_bin}" test -s "${MOLECULE_VM_SCENARIO}"
   else
-    "$@"
+    "${molecule_bin}" "$@"
   fi
 }
 
@@ -208,6 +206,8 @@ if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
   return 0
 fi
 
+set -u
+
 mode="${1:-}"
 
 if [[ -z "${mode}" ]]; then
@@ -220,7 +220,7 @@ case "${mode}" in
     target="${2:-}"
     env_file="${3:-.molecule-vm.env}"
     [[ -n "${target}" ]] || { usage; exit 1; }
-    load_target "${target}" "${env_file}"
+    load_target "${target}" "${env_file}" || exit 1
     print_exports
     ;;
   run)

--- a/scripts/molecule-vm-env.sh
+++ b/scripts/molecule-vm-env.sh
@@ -231,8 +231,9 @@ case "${mode}" in
     ;;
   run)
     target="${2:-}"
+    [[ -n "${target}" ]] || { usage; exit 1; }
     env_file=".molecule-vm.env"
-    shift 2 || true
+    shift 2
     if [[ "${1:-}" != "--" && -n "${1:-}" ]]; then
       env_file="$1"
       shift
@@ -240,7 +241,6 @@ case "${mode}" in
     if [[ "${1:-}" == "--" ]]; then
       shift
     fi
-    [[ -n "${target}" ]] || { usage; exit 1; }
     run_target "${target}" "${env_file}" "$@"
     ;;
   run-both)

--- a/scripts/molecule-vm-env.sh
+++ b/scripts/molecule-vm-env.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+
+set -u
+
+usage() {
+  cat <<'EOF'
+Usage:
+  source scripts/molecule-vm-env.sh <ubuntu|almalinux> [env-file]
+  scripts/molecule-vm-env.sh print <ubuntu|almalinux> [env-file]
+  scripts/molecule-vm-env.sh run <ubuntu|almalinux> [env-file] [-- molecule-args...]
+  scripts/molecule-vm-env.sh run-both [env-file]
+
+Modes:
+  source/load  Load one target into the current shell.
+  print        Print export statements for one target.
+  run          Run Molecule for one target with loaded env.
+  run-both     Run Ubuntu and AlmaLinux VM scenarios in parallel.
+
+Examples:
+  source scripts/molecule-vm-env.sh ubuntu
+  eval "$(scripts/molecule-vm-env.sh print almalinux)"
+  scripts/molecule-vm-env.sh run ubuntu
+  scripts/molecule-vm-env.sh run-both
+EOF
+}
+
+load_env_file() {
+  local env_file="$1"
+
+  if [[ -f "${env_file}" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "${env_file}"
+    set +a
+  fi
+}
+
+first_set_value() {
+  local default_value="$1"
+  shift
+
+  local var_name
+  for var_name in "$@"; do
+    if [[ -n "${var_name}" && -n "${!var_name:-}" ]]; then
+      printf '%s\n' "${!var_name}"
+      return 0
+    fi
+  done
+
+  printf '%s\n' "${default_value}"
+}
+
+resolve_target() {
+  local target="$1"
+
+  case "${target}" in
+    ubuntu)
+      MOLECULE_VM_SCENARIO="vm_ubuntu"
+      TARGET_PREFIX="MOLECULE_VM_UBUNTU"
+      ;;
+    almalinux|alma)
+      MOLECULE_VM_SCENARIO="vm_almalinux"
+      TARGET_PREFIX="MOLECULE_VM_ALMALINUX"
+      ;;
+    *)
+      echo "Unknown target: ${target}" >&2
+      echo "Supported targets: ubuntu, almalinux" >&2
+      return 1
+      ;;
+  esac
+}
+
+load_target() {
+  local target="$1"
+  local env_file="$2"
+  local host_var
+  local user_var
+  local port_var
+  local key_var
+  local ssh_args_var
+
+  load_env_file "${env_file}"
+  resolve_target "${target}" || return 1
+
+  host_var="${TARGET_PREFIX}_HOST"
+  user_var="${TARGET_PREFIX}_USER"
+  port_var="${TARGET_PREFIX}_PORT"
+  key_var="${TARGET_PREFIX}_KEY"
+  ssh_args_var="${TARGET_PREFIX}_SSH_COMMON_ARGS"
+
+  export MOLECULE_VM_HOST="$(first_set_value "${MOLECULE_VM_HOST:-}" "${host_var}")"
+  export MOLECULE_VM_USER="$(first_set_value "${MOLECULE_VM_USER:-brightos}" "${user_var}")"
+  export MOLECULE_VM_PORT="$(first_set_value "${MOLECULE_VM_PORT:-22}" "${port_var}")"
+  export MOLECULE_VM_KEY="$(first_set_value "${MOLECULE_VM_KEY:-}" "${key_var}")"
+  export MOLECULE_VM_SSH_COMMON_ARGS="$(first_set_value "${MOLECULE_VM_SSH_COMMON_ARGS:--o StrictHostKeyChecking=accept-new}" "${ssh_args_var}")"
+  export MOLECULE_VM_SCENARIO
+
+  if [[ -z "${MOLECULE_VM_HOST}" ]]; then
+    echo "Missing host for target '${target}'." >&2
+    echo "Set ${host_var} (or MOLECULE_VM_HOST) in ${env_file}." >&2
+    return 1
+  fi
+
+  if [[ -z "${MOLECULE_VM_KEY}" ]]; then
+    echo "Missing SSH key for target '${target}'." >&2
+    echo "Set ${key_var} (or MOLECULE_VM_KEY) in ${env_file}." >&2
+    return 1
+  fi
+}
+
+print_summary() {
+  local target="$1"
+
+  echo "Loaded Molecule VM target: ${target}"
+  echo "  scenario: ${MOLECULE_VM_SCENARIO}"
+  echo "  host:     ${MOLECULE_VM_HOST}"
+  echo "  user:     ${MOLECULE_VM_USER}"
+  echo "  port:     ${MOLECULE_VM_PORT}"
+  echo "  key:      ${MOLECULE_VM_KEY}"
+  echo
+  echo "Next command: molecule test -s ${MOLECULE_VM_SCENARIO}"
+}
+
+print_exports() {
+  printf 'export MOLECULE_VM_HOST=%q\n' "${MOLECULE_VM_HOST}"
+  printf 'export MOLECULE_VM_USER=%q\n' "${MOLECULE_VM_USER}"
+  printf 'export MOLECULE_VM_PORT=%q\n' "${MOLECULE_VM_PORT}"
+  printf 'export MOLECULE_VM_KEY=%q\n' "${MOLECULE_VM_KEY}"
+  printf 'export MOLECULE_VM_SSH_COMMON_ARGS=%q\n' "${MOLECULE_VM_SSH_COMMON_ARGS}"
+  printf 'export MOLECULE_VM_SCENARIO=%q\n' "${MOLECULE_VM_SCENARIO}"
+}
+
+run_target() {
+  local target="$1"
+  local env_file="$2"
+  local molecule_bin=""
+  shift 2
+
+  load_target "${target}" "${env_file}" || return 1
+
+  if [[ -n "${MOLECULE_BIN:-}" ]]; then
+    molecule_bin="${MOLECULE_BIN}"
+  elif [[ -x ".venv/bin/molecule" ]]; then
+    molecule_bin=".venv/bin/molecule"
+  elif command -v molecule >/dev/null 2>&1; then
+    molecule_bin="$(command -v molecule)"
+  else
+    echo "Could not find a Molecule executable." >&2
+    echo "Set MOLECULE_BIN or activate your virtual environment first." >&2
+    return 1
+  fi
+
+  if [[ "$#" -eq 0 ]]; then
+    "${molecule_bin}" test -s "${MOLECULE_VM_SCENARIO}"
+  else
+    "$@"
+  fi
+}
+
+run_both_targets() {
+  local env_file="$1"
+  local log_dir=".molecule-vm-logs"
+  local ubuntu_pid
+  local alma_pid
+  local ubuntu_rc=0
+  local alma_rc=0
+
+  mkdir -p "${log_dir}"
+
+  (
+    run_target ubuntu "${env_file}"
+  ) >"${log_dir}/vm_ubuntu.log" 2>&1 &
+  ubuntu_pid=$!
+
+  (
+    run_target almalinux "${env_file}"
+  ) >"${log_dir}/vm_almalinux.log" 2>&1 &
+  alma_pid=$!
+
+  echo "Started parallel Molecule runs:"
+  echo "  ubuntu:      PID ${ubuntu_pid}, log ${log_dir}/vm_ubuntu.log"
+  echo "  almalinux: PID ${alma_pid}, log ${log_dir}/vm_almalinux.log"
+
+  wait "${ubuntu_pid}" || ubuntu_rc=$?
+  wait "${alma_pid}" || alma_rc=$?
+
+  echo
+  echo "Run summary:"
+  echo "  ubuntu:      exit ${ubuntu_rc}"
+  echo "  almalinux: exit ${alma_rc}"
+
+  if [[ "${ubuntu_rc}" -ne 0 || "${alma_rc}" -ne 0 ]]; then
+    return 1
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  target="${1:-}"
+  env_file="${2:-.molecule-vm.env}"
+
+  if [[ -z "${target}" ]]; then
+    usage
+    return 1
+  fi
+
+  load_target "${target}" "${env_file}" || return 1
+  print_summary "${target}"
+  return 0
+fi
+
+mode="${1:-}"
+
+if [[ -z "${mode}" ]]; then
+  usage
+  exit 1
+fi
+
+case "${mode}" in
+  print)
+    target="${2:-}"
+    env_file="${3:-.molecule-vm.env}"
+    [[ -n "${target}" ]] || { usage; exit 1; }
+    load_target "${target}" "${env_file}"
+    print_exports
+    ;;
+  run)
+    target="${2:-}"
+    env_file="${3:-.molecule-vm.env}"
+    shift 3 || true
+    if [[ "${1:-}" == "--" ]]; then
+      shift
+    fi
+    [[ -n "${target}" ]] || { usage; exit 1; }
+    run_target "${target}" "${env_file}" "$@"
+    ;;
+  run-both)
+    env_file="${2:-.molecule-vm.env}"
+    run_both_targets "${env_file}"
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/scripts/molecule-vm-env.sh
+++ b/scripts/molecule-vm-env.sh
@@ -192,24 +192,23 @@ run_both_targets() {
   fi
 }
 
-if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
-  target="${1:-}"
-  env_file="${2:-.molecule-vm.env}"
+sourced_mode() {
+  local target="${1:-}"
+  local env_file="${2:-.molecule-vm.env}"
 
   if [[ -z "${target}" ]]; then
     usage
-    unset target env_file
     return 1
   fi
 
-  if ! load_target "${target}" "${env_file}"; then
-    unset target env_file
-    return 1
-  fi
-
+  load_target "${target}" "${env_file}" || return 1
   print_summary "${target}"
-  unset target env_file
   return 0
+}
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  sourced_mode "$1" "$2"
+  return $?
 fi
 
 set -u

--- a/scripts/molecule-vm-env.sh
+++ b/scripts/molecule-vm-env.sh
@@ -198,11 +198,17 @@ if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
 
   if [[ -z "${target}" ]]; then
     usage
+    unset target env_file
     return 1
   fi
 
-  load_target "${target}" "${env_file}" || return 1
+  if ! load_target "${target}" "${env_file}"; then
+    unset target env_file
+    return 1
+  fi
+
   print_summary "${target}"
+  unset target env_file
   return 0
 fi
 


### PR DESCRIPTION
RedHat verification paths existed/were planned, but no Molecule scenario ran them automatically. This PR adds a RedHat-family Molecule scenario:

- Adds a RedHat-family Molecule scenario using a supported target image.
- Reuses the shared playbooks where practical so Debian and RedHat scenarios validate the same core expectations.
- Ensures the scenario is suitable for firewall, network, and GUI package verification work.
- Updates test documentation to include the new scenario.

It also adds VM-based scenarios (AlmaLinux and Ubuntu) to ensure all features can be tested appropriately.