### PR TITLE
Clarify disability scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ suitable for people with learning difficulties. Initially, this is through the
 use of an Ansible playbook, applied to a minimal Ubuntu or AlmaLinux
 installation.
 
+Current BrightOS scope is intentionally focused on learning disability. Support
+for other disability categories (for example vision, hearing, or motor needs)
+is acceptable future work, but is not the current engineering target.
+
 I encourage you to read about the [Mission](docs/Mission.md).
 
 -- [Rob Pomeroy](https://pomeroy.me/contact "contact me via my website") |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![BrightOS logo - Tux mascot in wheelchair with lightbulb](images/BrightOS.png)
 
 Welcome to the BrightOS project, which aims to create a GNU/Linux distribution
-suitable for people with learning difficulties. Initially, this is through the
+suitable for people with a learning disability. Initially, this is through the
 use of an Ansible playbook, applied to a minimal Ubuntu or AlmaLinux
 installation.
 

--- a/docs/Accessibility.md
+++ b/docs/Accessibility.md
@@ -1,14 +1,16 @@
 ## Accessibility guidelines
 
 It is not possible to build a *simple* operating system that specialises in
-meeting *all* needs. BrightOS aims to accommodate:
+meeting *all* needs.
 
-* Fine motor control limitations (e.g. games need not require precise mouse
-  movements)
-* Mild vision impairment (audible feedback desirable, but not necessarily full
-  text-to-speech synthesis)
-* Learning difficulties (games involving repetition and very slowly increasing
-  difficulty levels help here)
+Current BrightOS scope is focused on learning disability. In this phase, we
+prioritise:
 
-These are not hard-and-fast rules however. Individual games and applications may
-not necessarily meet all guidelines.
+* reduced cognitive load and simpler user choices
+* safer defaults for supervised or minimally supervised use
+* educational and repetitive learning-friendly applications
+
+Support for other disability categories (for example vision, hearing, or motor
+needs) is not rejected, but is deferred for future work. Individual games and
+applications may provide incidental benefit outside current scope, but those
+benefits are not presently treated as acceptance criteria.

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -1,14 +1,14 @@
 # Features
 
 Current feature design is oriented toward safe, focused computer use for users
-with learning difficulties.
+with a learning disability.
 
 ## DNS
 
 This project forcibly sets specific DNS servers (the `dns_servers` variable in
 `config.yml`). The recommended approach is to use the OpenDNS FamilyShield
 servers, which provide some protection against content unsuitable for children
-or users with learning difficulties.
+or users with a learning disability.
 
 ## Content filtering
 

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -1,11 +1,14 @@
 # Features
 
+Current feature design is oriented toward safe, focused computer use for users
+with learning difficulties.
+
 ## DNS
 
 This project forcibly sets specific DNS servers (the `dns_servers` variable in
 `config.yml`). The recommended approach is to use the OpenDNS FamilyShield
 servers, which provide some protection against content unsuitable for children
-or particularly vulnerable people.
+or users with learning difficulties.
 
 ## Content filtering
 

--- a/docs/Implementation plan.md
+++ b/docs/Implementation plan.md
@@ -4,10 +4,10 @@
 
 As a general rule (with possible exceptions):
 
-1. Prioritise needs of users with learning disabilities over developer convenience or platform
-   completeness.
-2. Prioritise user safety and learning-disability usability outcomes before infrastructure or
-   packaging improvements.
+1. Prioritise needs of users with learning disabilities over developer
+   convenience or platform completeness.
+2. Prioritise user safety and learning-disability usability outcomes before
+   infrastructure or packaging improvements.
 3. Prefer changes that can be verified automatically in Molecule.
 4. Keep each iteration narrow enough to implement, review, and test in one PR.
 

--- a/docs/Implementation plan.md
+++ b/docs/Implementation plan.md
@@ -23,7 +23,7 @@ and safety, but the current verification layer does not test those outcomes.
 STATUS: COMPLETE.
 
 Why this matters:
-Users with learning difficulties need dependable, repeatable system behaviour.
+Users with a learning disability need dependable, repeatable system behaviour.
 Presently, the verify playbook does not catch regressions in safety or
 learning-focused controls.
 

--- a/docs/Implementation plan.md
+++ b/docs/Implementation plan.md
@@ -4,28 +4,28 @@
 
 As a general rule (with possible exceptions):
 
-1. Prioritise needs of disabled users over developer convenience or platform
+1. Prioritise needs of users with learning disabilities over developer convenience or platform
    completeness.
-2. Prioritise user safety and accessibility outcomes before infrastructure or
+2. Prioritise user safety and learning-disability usability outcomes before infrastructure or
    packaging improvements.
 3. Prefer changes that can be verified automatically in Molecule.
 4. Keep each iteration narrow enough to implement, review, and test in one PR.
 
 ## Priority Order
 
-### P0: Define and verify disability-critical outcomes
+### P0: Define and verify learning-disability-critical outcomes
 
-This repository has strong stated goals around accessibility and safety, but the
-current verification layer does not test those outcomes.
+This repository has strong stated goals around learning-disability usability
+and safety, but the current verification layer does not test those outcomes.
 
 #### 1. Replace placeholder verification with real assertions
 
 STATUS: COMPLETE.
 
 Why this matters:
-Users with learning difficulties and other disabilities need dependable,
-repeatable system behaviour. Presently, the verify playbook does not catch
-regressions in safety or accessibility controls.
+Users with learning difficulties need dependable, repeatable system behaviour.
+Presently, the verify playbook does not catch regressions in safety or
+learning-focused controls.
 
 Current gap:
 
@@ -38,7 +38,7 @@ Implementation tasks:
 - Assert protective DNS configuration is applied.
 - Assert firewall configuration is present and active where supported.
 - Assert proxy configuration is installed when enabled.
-- Assert required accessibility-oriented packages are present.
+- Assert required learning-focused packages are present.
 - Assert intentionally hidden or disallowed applications remain hidden or
   absent.
 
@@ -51,26 +51,26 @@ Likely files:
 
 Definition of done:
 
-- `molecule verify` fails when a safety or accessibility control regresses.
+- `molecule verify` fails when a safety or learning-focused control regresses.
 - Verification checks reflect actual BrightOS expectations rather than generic
   host health.
 
-#### 2. Turn accessibility goals into concrete acceptance criteria
+#### 2. Turn learning-disability goals into concrete acceptance criteria
 
 Why this matters:
-The project explicitly targets fine motor limitations, mild vision impairment,
-and learning difficulties, but those needs are not yet translated into
-actionable engineering requirements.
+The project targets learning disability outcomes, but those needs are not yet
+translated into actionable engineering requirements.
 
 Current gap:
-- [docs/Accessibility.md](../docs/Accessibility.md) describes intent, not testable
-  standards.
+- [docs/Accessibility.md](../docs/Accessibility.md) describes intent, but current
+  scope boundaries and testable standards for learning disability need to be
+  clearer.
 
 Implementation tasks:
-- Define minimum supported experience for each target need category.
+- Define minimum supported experience for each learning-disability user profile.
 - Identify which settings, apps, or restrictions implement each requirement.
 - Mark which requirements are mandatory for every install and which are
-  optional profiles.
+  future/deferred profiles.
 - Link each requirement to a verification check where possible.
 
 Likely files:
@@ -80,7 +80,7 @@ Likely files:
 - [molecule/resources/playbooks/verify.yml](../molecule/resources/playbooks/verify.yml)
 
 Definition of done:
-- Accessibility requirements can be used as acceptance criteria during PR
+- Learning-disability requirements can be used as acceptance criteria during PR
   review.
 - Each requirement is either automated, manually testable, or explicitly marked
   as future work.
@@ -152,7 +152,7 @@ Definition of done:
 STATUS: COMPLETE.
 
 Why this matters:
-Accessible and educational desktop software is part of the user value of
+Learning-focused and educational desktop software is part of the user value of
 BrightOS. Missing apps on one supported OS family weakens that promise.
 
 Current gap:
@@ -164,7 +164,7 @@ Implementation tasks:
 - If yes, resolve the squashfs/module issue in an idempotent, supportable way.
 - If no, replace Snap-based apps with supported RPM, Flatpak, or alternative
   packages.
-- Reassess package choices against accessibility goals rather than package
+- Reassess package choices against learning-disability goals rather than package
   availability alone.
 
 Likely files:
@@ -173,7 +173,7 @@ Likely files:
 - [docs/Accessibility.md](../docs/Accessibility.md)
 
 Definition of done:
-- RedHat-family installations deliver a defined minimum accessible app set.
+- RedHat-family installations deliver a defined minimum learning-focused app set.
 - The package path is automated and testable.
 
 #### 6. Define a minimum supported application set for target users
@@ -187,7 +187,7 @@ Current gap:
   baseline application profile tied to user needs.
 
 Implementation tasks:
-- Define the minimum app set by disability/user need category.
+- Define the minimum app set by learning-disability user need category.
 - Identify unsupported, distracting, or unsafe applications to hide or remove.
 - Document the rationale for each included app.
 - Add verification for presence or absence of those apps where feasible.
@@ -217,7 +217,7 @@ Current gap:
 Implementation tasks:
 - Turn the current brief list into a complete step-by-step guide.
 - Add a short validation checklist after installation.
-- Call out decisions that matter for disabled-user safety, such as DNS,
+- Call out decisions that matter for learning-disability user safety, such as DNS,
   browser, and user account configuration.
 - Link to testing and Windows/WSL guidance where appropriate.
 
@@ -236,8 +236,8 @@ Definition of done:
 STATUS: COMPLETE.
 
 Why this matters:
-Once disability-critical checks exist, they should run automatically so they do
-not depend on manual vigilance.
+Once learning-disability-critical checks exist, they should run automatically
+so they do not depend on manual vigilance.
 
 Current gap:
 - Mission-level CI/CD goals exist, but no visible repository automation is in
@@ -247,7 +247,7 @@ Implementation tasks:
 - Add CI for lint plus default Molecule scenario.
 - Run verification assertions as part of the gated workflow.
 - Keep CI scope small enough to stay reliable.
-- Treat accessibility and safety regressions as blocking failures.
+- Treat learning-disability and safety regressions as blocking failures.
 
 Likely files:
 - `.github/workflows/*`
@@ -256,7 +256,7 @@ Likely files:
 
 Definition of done:
 - PRs automatically run the baseline validation path.
-- Core safety and accessibility regressions are caught before merge.
+- Core safety and learning-disability regressions are caught before merge.
 
 ### P2: Resolve secondary backlog items
 
@@ -277,7 +277,7 @@ Definition of done:
 
 Why this matters:
 This is important for long-term adoption by non-technical users, but it should
-not displace more immediate accessibility and safety improvements.
+not displace more immediate learning-disability and safety improvements.
 
 Current gap:
 - [docs/Mission.md](../docs/Mission.md) lists ISO generation as a future goal,
@@ -292,18 +292,74 @@ Definition of done:
 - The distribution goal is represented as an ordered backlog, not a single
   large TODO.
 
+### P3: Deferred accessibility work
+
+Motor, vision, and hearing accessibility support remains a valuable long-term
+goal, but requires distinct user research, technical controls, and verification
+approaches. These profiles should be planned and resourced as future work
+rather than folded into learning-disability iterations.
+
+#### 11. Define motor, vision, and hearing accessibility profiles as deferred future work
+
+Why this matters:
+Current BrightOS scope prioritises learning disability protection and
+cognitive simplification. Motor, vision, and hearing impairments require
+distinct technical controls (screen magnification, high-contrast themes,
+text-to-speech, audio cues, input adaptation) that deserve dedicated
+planning. Explicitly deferring these profiles reduces contributor confusion
+and clarifies that [docs/Accessibility.md](../docs/Accessibility.md) mentions
+them only as future possibilities.
+
+Current gap:
+- [docs/Accessibility.md](../docs/Accessibility.md) defers motor, vision, and
+  hearing support but provides no concrete backlog item.
+- No roadmap clarifies what motor, vision, or hearing implementation would
+  entail.
+- Contributors may propose font scaling or magnification features citing
+  Accessibility.md as prior work, without understanding current scope
+  boundaries.
+
+Implementation tasks:
+- Gather accessibility research on motor, vision, and hearing user needs
+  specific to learning and educational contexts.
+- Map each disability profile to required technical controls (for example:
+  vision → magnification, high contrast, font size; motor → input
+  acceleration, keyboard-only navigation; hearing → visual alerts,
+  captions).
+- Audit which applications and GNOME settings would need reconfiguration to
+  support each profile.
+- Decide whether to implement profiles incrementally, as optional
+  accessibility variants, or as a separate downstream distribution.
+- Plan a verification approach for each profile (for example: magnification
+  factor, contrast ratio, input latency thresholds).
+
+Likely files:
+- [docs/Accessibility.md](../docs/Accessibility.md)
+- [docs/Features.md](../docs/Features.md)
+- [docs/Security.md](../docs/Security.md)
+- [molecule/resources/playbooks/verify.yml](../molecule/resources/playbooks/verify.yml)
+
+Definition of done:
+- Each deferred profile (motor, vision, hearing) has explicit acceptance
+  criteria distinct from and subordinate to learning-disability scope.
+- The roadmap clearly marks this work as future, not current baseline.
+- Contributor guidance makes clear that motor, vision, and hearing
+  improvements are welcome as future PRs but should not block
+  learning-disability-focused iterations.
+
 ## Recommended Iteration Sequence
 
 1. Real verification assertions.
-2. Accessibility acceptance criteria.
+2. Learning-disability acceptance criteria and deferred-scope boundaries.
 3. RedHat DNS parity.
 4. RedHat Molecule scenario.
-5. RedHat accessible app path.
+5. RedHat learning-focused app path.
 6. Minimum supported application set.
 7. Expanded installation guide.
 8. CI for baseline validation.
 9. Hostname/domain decision.
 10. ISO pipeline milestones.
+11. Define motor, vision, and hearing accessibility profiles.
 
 ## Working Rule For Future Iterations
 
@@ -311,5 +367,5 @@ When choosing between two backlog items of similar effort, prefer the one that
 most directly improves one of these outcomes:
 
 1. Safety for vulnerable users.
-2. Accessibility for the intended user groups.
+2. Learning-disability usability for the intended user group.
 3. Reliability of those protections through automated verification.

--- a/docs/Mission.md
+++ b/docs/Mission.md
@@ -40,14 +40,19 @@ difficulties. So the focus here is on safety and on enabling carers to control
 the system for the intended user. Spin-offs or bespoke configuration may be
 appropriate, to target other user groups, but that is not my initial objective.
 
+At this stage, BrightOS is intentionally scoped to learning disability. Support
+for other disability categories (for example vision, hearing, or motor needs)
+is considered future work rather than current project scope.
+
 # Goals
 
 Why this playbook? Why this approach?
 
 1. **Accessible fun.** This project should enhance the lives of people who may
-   otherwise struggle to use a computer.
+  otherwise struggle to use a computer due to learning difficulties.
 2. **Safety.** When preparing a computer environment for vulnerable people,
-   their safety is of paramount importance.
+  especially users with learning difficulties, their safety is of paramount
+  importance.
 3. **Longevity.** Many great, education-focused Linux distributions have started
    well but fizzled out. A low-maintenance strategy is key to survival of a
    project of this nature. An orchestration approach reduces much of the work

--- a/docs/Mission.md
+++ b/docs/Mission.md
@@ -6,7 +6,7 @@ to our twins Morgan and James. Due to a [condition during
 pregnancy](https://en.wikipedia.org/wiki/Twin-to-twin_transfusion_syndrome) our
 boys both acquired profound disabilities. Morgan, who passed away in 2024, had
 severe spastic cerebral palsy, was quadriplegic and vision impaired. James has
-severe learning difficulties, is on the autistic spectrum and suffers from
+severe a learning disability, is on the autistic spectrum and suffers from
 anxiety.
 
 The following years have been a massive learning experience and, I hope,
@@ -18,10 +18,10 @@ specialist bath for Morgan came in at about £10,000, for example.)
 
 It does not have to be costly, to meet computing needs. This open source (free!)
 repository contains an [Ansible](https://www.ansible.com/) playbook for
-customising Linux to help users with learning difficulties. The initial aim of
+customising Linux to help users with a learning disability. The initial aim of
 this project is to create an Ansible build that converts a Linux installation
-into something suitable for users (particularly children) with learning
-difficulties. Later, we may take a more direct approach, creating a Linux
+into something suitable for users (particularly children) with a learning
+disability. Later, we may take a more direct approach, creating a Linux
 distribution with installer.
 
 Why Linux rather than Windows? Several reasons:
@@ -35,9 +35,9 @@ Why Linux rather than Windows? Several reasons:
   software and use orchestration extensively. It's much easier for me to achieve
   this project's goals with Linux.
 
-I'm personally most interested in the protection of users with learning
-difficulties. So the focus here is on safety and on enabling carers to control
-the system for the intended user. Spin-offs or bespoke configuration may be
+I'm personally most interested in the protection of users with a learning
+disability. So the focus here is on safety and on enabling carers to control the
+system for the intended user. Spin-offs or bespoke configuration may be
 appropriate, to target other user groups, but that is not my initial objective.
 
 At this stage, BrightOS is intentionally scoped to learning disability. Support
@@ -49,9 +49,9 @@ is considered future work rather than current project scope.
 Why this playbook? Why this approach?
 
 1. **Accessible fun.** This project should enhance the lives of people who may
-  otherwise struggle to use a computer due to learning difficulties.
+  otherwise struggle to use a computer due to a learning disability.
 2. **Safety.** When preparing a computer environment for vulnerable people,
-  especially users with learning difficulties, their safety is of paramount
+  especially users with a learning disability, their safety is of paramount
   importance.
 3. **Longevity.** Many great, education-focused Linux distributions have started
    well but fizzled out. A low-maintenance strategy is key to survival of a
@@ -79,26 +79,26 @@ but I have not tested that.
 # Sources for other ideas
 
 There are some existing child-friendly Linux distributions. These do not focus
-on the needs of users with learning difficulties (a cause dear to my heart) and
+on the needs of users with a learning disability (a cause dear to my heart) and
 many of them suffer from a lack of ongoing maintenance. Nevertheless, they are
 very useful sources of inspiration for this project.
 
 * Ubermix: still under active development; focused on children and education
-  (but not learning difficulties); has some strong features including "20 second
+  (but not learning disability); has some strong features including "20 second
   quick recovery mechanism"
 * Elementary Linux OS: mature, actively developed OS built on Ubuntu/Gnome;
-  focused on education and ease-of-use, but not aimed at learning difficulties
+  focused on education and ease-of-use, but not aimed at learning disability
 * Debian Edu/Skolelinux: a mature project; last release Jul 2019 after a
-  two-year hiatus; focus is education rather than learning difficulties
-* DoudouLinux: the OS I currently use for my son James (on a machine that is not
-  network-connected); apparently abandoned in 2015
+  two-year hiatus; focus is education rather than learning disability
+* DoudouLinux: an OS I have previously use for my son James (on a machine that
+  was not network-connected); apparently abandoned in 2015
 * Edubuntu: was a benchmark at one point, but now seems to be obsolete; the
   latest release was in 2016
 * Qimo 4 Kids: project officially retired in 2016
 * openSUSE-Edu Li-f-e: some good packages and features; project stalled in 2016;
-  an[Ubuntu version
-  exists](https://sourceforge.net/projects/cyberorg-home/files/Li-f-e/) but its
-  future is not clear; not aimed at learning difficulties
+  an
+  [Ubuntu version exists](https://sourceforge.net/projects/cyberorg-home/files/Li-f-e/)
+  but its future is not clear; not aimed at learning disability
 * LinuxKidX: last updated in 2016, seems to have been abandoned
 * UberStudent: aimed at secondary and higher education; last release 2015
 * Educado: particularly interesting due to its inclusion of parental controls;
@@ -108,4 +108,4 @@ very useful sources of inspiration for this project.
 * Leeenux Kids: a child-friendly version of Leeenux, a *non-free* OS that
   specifically targets netbooks (like the Asus Eee PC); less generalised from a
   hardware perspective than most other Linux distributions; documentation about
-  Kids version is scant; not focused on learning difficulties
+  Kids version is scant; not focused on learning disability

--- a/docs/Mission.md
+++ b/docs/Mission.md
@@ -49,10 +49,10 @@ is considered future work rather than current project scope.
 Why this playbook? Why this approach?
 
 1. **Accessible fun.** This project should enhance the lives of people who may
-  otherwise struggle to use a computer due to a learning disability.
+   otherwise struggle to use a computer due to a learning disability.
 2. **Safety.** When preparing a computer environment for vulnerable people,
-  especially users with a learning disability, their safety is of paramount
-  importance.
+   especially users with a learning disability, their safety is of paramount
+   importance.
 3. **Longevity.** Many great, education-focused Linux distributions have started
    well but fizzled out. A low-maintenance strategy is key to survival of a
    project of this nature. An orchestration approach reduces much of the work

--- a/docs/Mission.md
+++ b/docs/Mission.md
@@ -6,7 +6,7 @@ to our twins Morgan and James. Due to a [condition during
 pregnancy](https://en.wikipedia.org/wiki/Twin-to-twin_transfusion_syndrome) our
 boys both acquired profound disabilities. Morgan, who passed away in 2024, had
 severe spastic cerebral palsy, was quadriplegic and vision impaired. James has
-severe a learning disability, is on the autistic spectrum and suffers from
+a severe learning disability, is on the autistic spectrum and suffers from
 anxiety.
 
 The following years have been a massive learning experience and, I hope,
@@ -90,7 +90,7 @@ very useful sources of inspiration for this project.
   focused on education and ease-of-use, but not aimed at learning disability
 * Debian Edu/Skolelinux: a mature project; last release Jul 2019 after a
   two-year hiatus; focus is education rather than learning disability
-* DoudouLinux: an OS I have previously use for my son James (on a machine that
+* DoudouLinux: an OS I have previously used for my son James (on a machine that
   was not network-connected); apparently abandoned in 2015
 * Edubuntu: was a benchmark at one point, but now seems to be obsolete; the
   latest release was in 2016

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -1,9 +1,13 @@
 # Security
 
-This is a project aimed at serving the needs of a vulnerable class of people.
-Nothing this project achieves will eliminate the responsibilities and duties of
-parents and carers. It is hoped however, that it will be reasonably safe to
-leave a user of BrightOS with minimal supervision.
+This project is currently aimed at serving users with learning difficulties,
+especially where carers need a safer and simpler desktop setup. Nothing this
+project achieves will eliminate the responsibilities and duties of parents and
+carers. It is hoped however, that it will be reasonably safe to leave a user of
+BrightOS with minimal supervision.
+
+Support for other disability categories (for example vision, hearing, or motor
+needs) is acceptable future work, but is outside current project scope.
 
 ## Safe from malware
 

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -1,6 +1,6 @@
 # Security
 
-This project is currently aimed at serving users with learning difficulties,
+This project is currently aimed at serving users with a learning disability,
 especially where carers need a safer and simpler desktop setup. Nothing this
 project achieves will eliminate the responsibilities and duties of parents and
 carers. It is hoped however, that it will be reasonably safe to leave a user of

--- a/molecule/resources/playbooks/verify.yml
+++ b/molecule/resources/playbooks/verify.yml
@@ -244,7 +244,7 @@
         that: "dns_servers[0] in (dhclient_content.content | b64decode)"
         fail_msg: >
           Protective DNS server {{ dns_servers[0] }} is not present in
-          /etc/dhcp/dhclient.conf — users with learning difficulties may
+          /etc/dhcp/dhclient.conf — users with a learning disability may
           be exposed to unfiltered DNS
       when: ansible_facts['os_family'] == "Debian"
 
@@ -277,7 +277,7 @@
         that: "dns_servers[0] in (resolv_conf_content.content | b64decode)"
         fail_msg: >
           Protective DNS server {{ dns_servers[0] }} is not present in
-          /etc/resolv.conf — users with learning difficulties may be
+          /etc/resolv.conf — users with a learning disability may be
           exposed to unfiltered DNS
       when:
         - ansible_facts['os_family'] == "RedHat"
@@ -348,7 +348,7 @@
         that: "(privoxy_content.content | b64decode | regex_search('(?m)^enforce-blocks\\s+1\\s*$')) is not none"
         fail_msg: >
           Privoxy enforce-blocks is not enabled — blocked content may be
-          reachable by users with learning difficulties
+          reachable by users with a learning disability
 
     - name: Check abp2privoxy script exists
       ansible.builtin.stat:
@@ -447,7 +447,7 @@
         that: "'AutomaticLoginEnable=True' in (gdm_content.content | b64decode)"
         fail_msg: >
           AutomaticLoginEnable is not set to True in /etc/gdm3/custom.conf —
-          users with learning difficulties will be presented with a login
+          users with a learning disability will be presented with a login
           screen and asked for credentials
       when: ansible_facts['os_family'] == "Debian"
 
@@ -468,8 +468,8 @@
         that: gnome_setup_desktop.stat.exists
         fail_msg: >
           /etc/xdg/autostart/gnome-initial-setup-first-login.desktop does not
-          exist — the initial setup wizard may confuse users with learning
-          difficulties
+          exist — the initial setup wizard may confuse users with a learning
+          disability
 
     - name: Read gnome-initial-setup suppression file
       ansible.builtin.slurp:

--- a/molecule/resources/playbooks/verify.yml
+++ b/molecule/resources/playbooks/verify.yml
@@ -56,10 +56,10 @@
           - "'privoxy' in ansible_facts.packages or privoxy_binary.stat.exists"
         fail_msg: "privoxy is not installed"
 
-    - name: Assert required accessible desktop packages are present (Debian)
+    - name: Assert required learning-focused desktop packages are present (Debian)
       ansible.builtin.assert:
         that: "item in ansible_facts.packages"
-        fail_msg: "Required accessible desktop package '{{ item }}' is not installed"
+        fail_msg: "Required learning-focused desktop package '{{ item }}' is not installed"
       loop:
         - gcompris-qt
         - ktuberling
@@ -244,7 +244,8 @@
         that: "dns_servers[0] in (dhclient_content.content | b64decode)"
         fail_msg: >
           Protective DNS server {{ dns_servers[0] }} is not present in
-          /etc/dhcp/dhclient.conf — vulnerable users may use unprotected DNS
+          /etc/dhcp/dhclient.conf — users with learning difficulties may
+          be exposed to unfiltered DNS
       when: ansible_facts['os_family'] == "Debian"
 
     - name: Check /etc/resolv.conf exists (RedHat)
@@ -276,7 +277,8 @@
         that: "dns_servers[0] in (resolv_conf_content.content | b64decode)"
         fail_msg: >
           Protective DNS server {{ dns_servers[0] }} is not present in
-          /etc/resolv.conf — vulnerable users may use unprotected DNS
+          /etc/resolv.conf — users with learning difficulties may be
+          exposed to unfiltered DNS
       when:
         - ansible_facts['os_family'] == "RedHat"
         - not molecule_is_container
@@ -346,7 +348,7 @@
         that: "(privoxy_content.content | b64decode | regex_search('(?m)^enforce-blocks\\s+1\\s*$')) is not none"
         fail_msg: >
           Privoxy enforce-blocks is not enabled — blocked content may be
-          accessible to vulnerable users
+          reachable by users with learning difficulties
 
     - name: Check abp2privoxy script exists
       ansible.builtin.stat:
@@ -419,7 +421,7 @@
       when: firefox_install | bool
 
     # =========================================================================
-    # GNOME lockdown and accessibility settings
+    # GNOME lockdown and desktop simplification
     # =========================================================================
 
     - name: Check GDM configuration file exists (Debian)
@@ -445,7 +447,8 @@
         that: "'AutomaticLoginEnable=True' in (gdm_content.content | b64decode)"
         fail_msg: >
           AutomaticLoginEnable is not set to True in /etc/gdm3/custom.conf —
-          users will be presented with a login screen they cannot navigate
+          users with learning difficulties will be presented with a login
+          screen and asked for credentials
       when: ansible_facts['os_family'] == "Debian"
 
     - name: Assert automatic login is for the correct user
@@ -465,7 +468,8 @@
         that: gnome_setup_desktop.stat.exists
         fail_msg: >
           /etc/xdg/autostart/gnome-initial-setup-first-login.desktop does not
-          exist — the initial setup wizard may confuse target users
+          exist — the initial setup wizard may confuse users with learning
+          difficulties
 
     - name: Read gnome-initial-setup suppression file
       ansible.builtin.slurp:

--- a/molecule/resources/playbooks/verify.yml
+++ b/molecule/resources/playbooks/verify.yml
@@ -56,10 +56,10 @@
           - "'privoxy' in ansible_facts.packages or privoxy_binary.stat.exists"
         fail_msg: "privoxy is not installed"
 
-    - name: Assert required learning-focused desktop packages are present (Debian)
+    - name: Assert required desktop packages are present (Debian)
       ansible.builtin.assert:
         that: "item in ansible_facts.packages"
-        fail_msg: "Required learning-focused desktop package '{{ item }}' is not installed"
+        fail_msg: "Required desktop package '{{ item }}' is not installed"
       loop:
         - gcompris-qt
         - ktuberling


### PR DESCRIPTION
This PR adjusts documentation (and Molecule) to narrow the immediate focus of BrightOS to learning disability. Catering for other disaiblities (vision, hearing, motor, etc.) is deferred for now. They are acceptable goals, but not the primary focus at this stage.